### PR TITLE
Fix github clone url in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ La Bonne Boite is a [web site](https://labonneboite.pole-emploi.fr) and an [API]
 
 - Install Vagrant
 
-- Fetch labonneboite repository `git clone https://github.com/StartupPoleEmploi/labonneboite.git`
+- Fetch labonneboite repository `git clone https://github.com/StartupsPoleEmploi/labonneboite.git`
 
     - ensure your ssh public key has been properly setup
 


### PR DESCRIPTION
In the Readme, the "git clone" command refers to StartupPoleEmploi instead of StartupsPoleEmploi