### PR TITLE
Acantin/save 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Tests which can run in development:
     $ make test_api
     $ make test_integration
     $ make test_selenium
+    $ make test_scripts
 
 Tests which for some reason do not run in dev yet, only jenkins:
 

--- a/README.md
+++ b/README.md
@@ -218,9 +218,6 @@ Tests which can run in development:
     $ make test_integration
     $ make test_selenium
     $ make test_scripts
-
-Tests which for some reason do not run in dev yet, only jenkins:
-
     $ make test_integration
 
 You can run all tests with:

--- a/labonneboite/alembic/versions/bde9330b83fa_add_romes_to_remove_column.py
+++ b/labonneboite/alembic/versions/bde9330b83fa_add_romes_to_remove_column.py
@@ -1,0 +1,25 @@
+"""
+Add romes_to_remove column
+
+Revision ID: bde9330b83fa
+Revises: 1124e80be448
+Create Date: 2017-10-03 15:28:07.825231
+"""
+
+from alembic import op
+from sqlalchemy.dialects import mysql
+import sqlalchemy as sa
+
+
+# Revision identifiers, used by Alembic.
+revision = 'bde9330b83fa'
+down_revision = '1124e80be448'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('etablissements_admin_update', sa.Column('romes_to_remove',
+        mysql.TEXT(collation=u'utf8mb4_unicode_ci'), nullable=False))
+
+def downgrade():
+    op.drop_column('etablissements_admin_update', 'romes_to_remove')

--- a/labonneboite/common/models/office_admin.py
+++ b/labonneboite/common/models/office_admin.py
@@ -119,9 +119,14 @@ class OfficeAdminUpdate(CRUDMixin, Base):
 
     # Set `boost` to True to promote the offfice.
     boost = Column(Boolean, default=False, nullable=False)
+    
     # Stores a list of ROME codes as a string separated by `ROMES_SEPARATORS`.
     # If `romes_to_boost` is populated, boosting will be set only for specified ROME codes.
     romes_to_boost = Column(Text, default='', nullable=False)
+
+    # Stores a list of ROME codes as a string separated by `ROMES_SEPARATORS`.
+    # If `romes_to_remove` is populated, these ROME codes will not be indexed
+    romes_to_remove = Column(Text, default='', nullable=False)
 
     # Info to remove.
     remove_email = Column(Boolean, default=False, nullable=False)
@@ -169,13 +174,13 @@ class OfficeAdminUpdate(CRUDMixin, Base):
         codes = [v.strip() for v in re.split('|'.join(separators), codes) if v.strip()]
         return sorted(set(codes))
 
-    def romes_to_boost_as_html(self):
+    def romes_as_html(self, romes):
         """
         Returns the content of the `romes_to_boost` field as HTML.
         Used in the admin UI.
         """
         html = []
-        for rome in self.romes_as_list(self.romes_to_boost):
+        for rome in self.romes_as_list(romes):
             html.append(u"{0} - {1}".format(rome, settings.ROME_DESCRIPTIONS[rome]))
         return '<br>'.join(html)
 

--- a/labonneboite/common/search.py
+++ b/labonneboite/common/search.py
@@ -71,13 +71,13 @@ class Fetcher(object):
 
         # NAF, ROME and NAF codes.
         self.naf = kwargs.get('naf')
+
         self.rome = mapping_util.SLUGIFIED_ROME_LABELS[self.occupation_slug]
         mapper = mapping_util.Rome2NafMapper()
         if self.naf:
             self.naf_codes = mapper.map([self.rome], [self.naf])
         else:
-            self.naf_codes = mapper.map([self.rome])
-
+            self.naf_codes = {}
         # Other properties.
         self.alternative_rome_codes = {}
         self.alternative_distances = collections.OrderedDict()
@@ -238,12 +238,13 @@ def build_json_body_elastic_search(
     sort_attrs = []
 
     # Build filters.
-
-    filters = [{
-        "terms": {
-            "naf": naf_codes
-        }
-    }]
+    filters = []
+    if naf_codes:
+        filters = [{
+            "terms": {
+                "naf": naf_codes
+            }
+        }]
 
     # in some cases, a string is given as input, let's ensure it is an int from now on
     try:

--- a/labonneboite/common/search.py
+++ b/labonneboite/common/search.py
@@ -74,10 +74,11 @@ class Fetcher(object):
 
         self.rome = mapping_util.SLUGIFIED_ROME_LABELS[self.occupation_slug]
         mapper = mapping_util.Rome2NafMapper()
+        
+        # Empty list is needed to handle companies with ROME not related to their NAF
+        self.naf_codes = {}
         if self.naf:
             self.naf_codes = mapper.map([self.rome], [self.naf])
-        else:
-            self.naf_codes = {}
         # Other properties.
         self.alternative_rome_codes = {}
         self.alternative_distances = collections.OrderedDict()

--- a/labonneboite/scripts/create_index.py
+++ b/labonneboite/scripts/create_index.py
@@ -359,11 +359,11 @@ def get_scores_by_rome(office, office_to_update=None):
     if office_to_update:
         # Add unrelated rome for indexing (with boost)
         romes_to_boost = office_to_update.romes_as_list(office_to_update.romes_to_boost)
-        rome_codes += [romes for romes in romes_to_boost if romes not in rome_codes]
+        rome_codes += list(set(romes_to_boost) - set(rome_codes))
 
         # Remove unwanted romes
         romes_to_remove = office_to_update.romes_as_list(office_to_update.romes_to_remove)
-        rome_codes = [rome_code for rome_code in rome_codes if rome_code not in romes_to_remove]
+        rome_codes = list(set(rome_codes) - set(romes_to_remove))
 
     for rome_code in rome_codes:
         score = 0

--- a/labonneboite/scripts/create_index.py
+++ b/labonneboite/scripts/create_index.py
@@ -360,10 +360,7 @@ def get_scores_by_rome(office, office_to_update=None):
         romes_to_boost = office_to_update.romes_as_list(office_to_update.romes_to_boost)
 
         # Add unrelated rome for indexing (with boost)
-        for rome_to_boost in romes_to_boost:
-            if rome_to_boost not in rome_codes:
-                rome_codes.append(rome_to_boost)
-
+        rome_codes = rome_codes + [romes for romes in romes_to_boost if romes not in rome_codes]
 
     for rome_code in rome_codes:
         score = 0

--- a/labonneboite/scripts/create_index.py
+++ b/labonneboite/scripts/create_index.py
@@ -359,6 +359,12 @@ def get_scores_by_rome(office, office_to_update=None):
     if office_to_update:
         romes_to_boost = office_to_update.romes_as_list(office_to_update.romes_to_boost)
 
+        # Add unrelated rome for indexing (with boost)
+        for rome_to_boost in romes_to_boost:
+            if rome_to_boost not in rome_codes:
+                rome_codes.append(rome_to_boost)
+
+
     for rome_code in rome_codes:
         score = 0
 

--- a/labonneboite/scripts/create_index.py
+++ b/labonneboite/scripts/create_index.py
@@ -359,7 +359,7 @@ def get_scores_by_rome(office, office_to_update=None):
     if office_to_update:
         # Add unrelated rome for indexing (with boost)
         romes_to_boost = office_to_update.romes_as_list(office_to_update.romes_to_boost)
-        rome_codes = rome_codes + [romes for romes in romes_to_boost if romes not in rome_codes]
+        rome_codes += [romes for romes in romes_to_boost if romes not in rome_codes]
 
         # Remove unwanted romes
         romes_to_remove = office_to_update.romes_as_list(office_to_update.romes_to_remove)

--- a/labonneboite/scripts/create_index.py
+++ b/labonneboite/scripts/create_index.py
@@ -357,10 +357,13 @@ def get_scores_by_rome(office, office_to_update=None):
 
     romes_to_boost = []
     if office_to_update:
-        romes_to_boost = office_to_update.romes_as_list(office_to_update.romes_to_boost)
-
         # Add unrelated rome for indexing (with boost)
+        romes_to_boost = office_to_update.romes_as_list(office_to_update.romes_to_boost)
         rome_codes = rome_codes + [romes for romes in romes_to_boost if romes not in rome_codes]
+
+        # Remove unwanted romes
+        romes_to_remove = office_to_update.romes_as_list(office_to_update.romes_to_remove)
+        rome_codes = [rome_code for rome_code in rome_codes if rome_code not in romes_to_remove]
 
     for rome_code in rome_codes:
         score = 0

--- a/labonneboite/tests/scripts/test_create_index.py
+++ b/labonneboite/tests/scripts/test_create_index.py
@@ -282,6 +282,46 @@ class UpdateOfficesTest(CreateIndexBaseTest):
                         score=office.score, rome_code=rome, naf_code=office.naf)
                     self.assertTrue(score < script.SCORE_FOR_ROME_MINIMUM)
 
+    def test_update_office_boost_unrelated_romes(self):
+        """
+        Test `update_offices` to update an office: boost score for specific ROME codes
+        but with romes not associated to the office.
+        """
+        mapper = mapping_util.Rome2NafMapper()
+        romes_for_office = [rome.code for rome in mapper.romes_for_naf(self.office.naf)]
+
+        self.assertNotIn(u"D1506", romes_for_office) # Rome not related to the office
+        self.assertIn(u"D1507", romes_for_office) # Rome related to the office
+
+        office_to_update = OfficeAdminUpdate(
+            siret=self.office.siret,
+            name=self.office.company_name,
+            boost=True,
+            romes_to_boost=u"D1506\nD1507",  # Boost score only for those ROME.
+        )
+        office_to_update.save()
+
+        script.update_offices(index=self.ES_TEST_INDEX)
+        time.sleep(1)  # Sleep required by ES to register new documents.
+
+        office = Office.get(self.office.siret)
+        res = self.es.get(index=self.ES_TEST_INDEX, doc_type=self.ES_OFFICE_TYPE, id=office.siret)
+
+        # Check boosted scores.
+        print res['_source']['scores_by_rome'].keys()
+        self.assertEquals(res['_source']['scores_by_rome']['D1506'], 100)
+        self.assertEquals(res['_source']['scores_by_rome']['D1507'], 100)
+
+        # Other scores should not be boosted.
+        for rome in romes_for_office:
+            if rome not in [u"D1507"]:
+                try:
+                    self.assertNotEqual(res['_source']['scores_by_rome'][rome], 100)
+                except KeyError:
+                    # Score for ROME has not been indexed because it was too low.
+                    score = scoring_util.get_score_adjusted_to_rome_code_and_naf_code(
+                        score=office.score, rome_code=rome, naf_code=office.naf)
+                    self.assertTrue(score < script.SCORE_FOR_ROME_MINIMUM)
 
 class UpdateOfficesGeolocationsTest(CreateIndexBaseTest):
     """

--- a/labonneboite/web/admin/views/office_admin_update.py
+++ b/labonneboite/web/admin/views/office_admin_update.py
@@ -178,7 +178,6 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
                 return False
 
             mapper = mapping_util.Rome2NafMapper()
-            office_romes = [item.code for item in mapper.romes_for_naf(office_to_update.naf)]
             for rome in OfficeAdminUpdate.romes_as_list(romes_to_boost):
                 if not mapper.romes_is_valid(rome):
                     msg = (
@@ -188,10 +187,6 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
                         % rome
                     )
                     flash(Markup(msg), 'error')
-                    return False
-                if rome not in office_romes:
-                    msg = u"`%s` n'est pas un code ROME lié au NAF de cette entreprise." % rome
-                    flash(msg, 'error')
                     return False
 
         return is_valid

--- a/labonneboite/web/admin/views/office_admin_update.py
+++ b/labonneboite/web/admin/views/office_admin_update.py
@@ -34,6 +34,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         'name',
         'boost',
         'romes_to_boost',
+        'romes_to_remove',
         'new_email',
         'new_phone',
         'new_website',
@@ -54,7 +55,8 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
     column_formatters = {
         'date_created': datetime_format,
         'date_updated': datetime_format,
-        'romes_to_boost': lambda view, context, model, name: Markup(model.romes_to_boost_as_html()),
+        'romes_to_boost': lambda view, context, model, name: Markup(model.romes_as_html(model.romes_to_boost)),
+        'romes_to_remove': lambda view, context, model, name: Markup(model.romes_as_html(model.romes_to_remove)),
     }
 
     column_labels = {
@@ -63,6 +65,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         'reason': u"Raison",
         'boost': u"Booster le score",
         'romes_to_boost': u"Limiter le boosting du score à certain codes ROME uniquement",
+        'romes_to_remove': u"Retirer des codes ROME associés à une entreprise",
         'new_email': u"Nouvel email",
         'new_phone': u"Nouveau téléphone",
         'new_website': u"Nouveau site web",
@@ -92,6 +95,13 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
             u"<br>"
             u"<a href=\"/data/romes-for-siret\" target=\"_blank\">Trouver les ROME pour un SIRET</a>."
         ),
+        'romes_to_remove': Markup(
+            u"Veuillez entrer un ROME par ligne."
+            u"<br>"
+            u"Si ce champ est renseigné, le(s) ROME spécifié(s) seront retirés pour cette entreprise."
+            u"<br>"
+            u"<a href=\"/data/romes-for-siret\" target=\"_blank\">Trouver les ROME pour un SIRET</a>."
+        ),
         'new_email': u"Laisser vide s'il n'y a pas de modification à apporter",
         'new_phone': u"Laisser vide s'il n'y a pas de modification à apporter",
         'new_website': u"Laisser vide s'il n'y a pas de modification à apporter",
@@ -106,6 +116,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         'name',
         'boost',
         'romes_to_boost',
+        'romes_to_remove',
         'new_email',
         'new_phone',
         'new_website',
@@ -128,6 +139,9 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
             'filters': [strip_filter],
         },
         'romes_to_boost': {
+            'filters': [strip_filter],
+        },
+        'romes_to_remove': {
             'filters': [strip_filter],
         },
         'new_email': {
@@ -162,6 +176,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
     def validate_form(self, form):
         is_valid = super(OfficeAdminUpdateModelView, self).validate_form(form)
 
+        # Code ROMES to boost or to add
         if is_valid and form.data.get('romes_to_boost'):
 
             romes_to_boost = form.data.get('romes_to_boost')
@@ -188,5 +203,35 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
                     )
                     flash(Markup(msg), 'error')
                     return False
+
+        # Codes ROMES to remove
+        if is_valid and form.data.get('romes_to_remove'):
+            romes_to_remove = form.data.get('romes_to_remove')
+
+            office_to_update = Office.query.filter_by(siret=form.data['siret']).first()
+            if not office_to_update:
+                msg = u"Le siret `%s` n'est pas présent sur LBB." % form.data['siret']
+                flash(msg, 'error')
+                return False
+
+            mapper = mapping_util.Rome2NafMapper()
+            office_romes = [item.code for item in mapper.romes_for_naf(office_to_update.naf)]
+            for rome in OfficeAdminUpdate.romes_as_list(romes_to_remove):
+
+                if not mapper.romes_is_valid(rome):
+                    msg = (
+                        u"`%s` n'est pas un code ROME valide."
+                        u"<br>"
+                        u"Assurez-vous de ne saisir qu'un élément par ligne."
+                        % rome
+                    )
+                    flash(Markup(msg), 'error')
+                    return False
+
+                if rome not in office_romes:
+                    msg = u"`%s` n'est pas un code ROME lié au NAF de cette entreprise." % rome
+                    flash(msg, 'error')
+                    return False
+
 
         return is_valid

--- a/labonneboite/web/admin/views/office_admin_update.py
+++ b/labonneboite/web/admin/views/office_admin_update.py
@@ -98,7 +98,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         'romes_to_remove': Markup(
             u"Veuillez entrer un ROME par ligne."
             u"<br>"
-            u"Si ce champ est renseigné, le(s) ROME spécifié(s) seront retirés pour cette entreprise."
+            u"Si ce champ est renseigné, le(s) ROME spécifié(s) ne seront plus associés à cette entreprise."
             u"<br>"
             u"<a href=\"/data/romes-for-siret\" target=\"_blank\">Trouver les ROME pour un SIRET</a>."
         ),
@@ -176,7 +176,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
     def validate_form(self, form):
         is_valid = super(OfficeAdminUpdateModelView, self).validate_form(form)
 
-        # Code ROMES to boost or to add
+        # Codes ROMES to boost or to add
         if is_valid and form.data.get('romes_to_boost'):
 
             romes_to_boost = form.data.get('romes_to_boost')

--- a/labonneboite/web/api/views.py
+++ b/labonneboite/web/api/views.py
@@ -125,8 +125,8 @@ def company_list():
     except (TypeError, ValueError):
         headcount_filter = settings.HEADCOUNT_WHATEVER
 
-    mapper = mapping_util.Rome2NafMapper()
-    naf_code_list = mapper.map(rome_code_list)
+    # No naf filter
+    naf_code_list = {}
 
     companies, companies_count = search.get_companies(
         naf_code_list,

--- a/labonneboite/web/api/views.py
+++ b/labonneboite/web/api/views.py
@@ -125,11 +125,12 @@ def company_list():
     except (TypeError, ValueError):
         headcount_filter = settings.HEADCOUNT_WHATEVER
 
-    # No naf filter
-    naf_code_list = {}
+    # No NAF filter
+    # Empty list is needed to handle companies with ROME not related to their NAF
+    naf_codes = {}
 
     companies, companies_count = search.get_companies(
-        naf_code_list,
+        naf_codes,
         rome_code,
         latitude,
         longitude,


### PR DESCRIPTION
Ajout d'un ROME hors du NAF de l'entreprise :  
- si un rome_to_boost a été ajouté, son score sera de 100
- Pas de filtre naf si la recherche est faite sur tous les secteurs (modifications reportées par l'API aussi)

Suppression d'un ROME du Naf de l'entreprise:
- Migration alembic pour ajouter la colonne
- Interface dans flask-admin 
- Aucun score n'est mis dans ES
 