### PR TITLE
Add contact_mode in API response

### DIFF
--- a/labonneboite/common/models/office.py
+++ b/labonneboite/common/models/office.py
@@ -11,6 +11,7 @@ from labonneboite.common import encoding as encoding_util
 from labonneboite.common import scoring as scoring_util
 from labonneboite.common.database import Base
 from labonneboite.common.load_data import load_city_codes
+from labonneboite.common import util
 from labonneboite.common.models.base import CRUDMixin
 from labonneboite.conf import settings
 
@@ -96,6 +97,7 @@ class Office(OfficeMixin, CRUDMixin, Base):
             'siret': self.siret,
             'stars': self.get_stars_for_rome_code(rome_code),
             'url': self.get_url_for_rome_code(rome_code),
+            'contact_mode': util.get_contact_mode_for_rome_and_naf(rome_code, self.naf),
             # Warning: the `distance` field is added by `get_companies_from_es_and_db`,
             # this is NOT a model field or property!
             'distance': self.distance,
@@ -275,25 +277,3 @@ class Office(OfficeMixin, CRUDMixin, Base):
                 return False
             return True
         return False
-
-
-CONTACT_MODE_STAGES = {
-    u"Se présenter spontanément": [
-        u"Se présenter à l'adresse indiquée avec CV et photo",
-        u"Demander le nom d'un contact pour relancer",
-        u"Relancer votre interlocuteur par téléphone",
-        u"Déclarer votre reprise d'emploi à Pôle emploi :-)",
-    ],
-    u"Envoyer un CV et une lettre de motivation": [
-        (u"Rechercher le nom d'un contact dans l'entreprise (google, kompass, linkedin, viadeo, votre réseau) "
-            u"pour lui adresser votre courrier/email"),
-        (u"Rechercher des informations économiques (projet, évolution) sur l'entreprise afin de personnaliser "
-            u"votre lettre de motivation"),
-        u"Envoyer votre CV et votre lettre de motivation",
-        u"Relancer votre interlocuteur par téléphone",
-        u"Préparer votre entretien",
-        u"Déclarer votre reprise d'emploi à Pôle emploi :-)",
-    ]
-}
-
-CONTACT_MODE_DEFAULT = u"Envoyer un CV et une lettre de motivation"

--- a/labonneboite/common/util.py
+++ b/labonneboite/common/util.py
@@ -11,7 +11,6 @@ from flask_login import current_user
 
 from labonneboite.conf import settings
 from labonneboite.common.load_data import load_contact_modes
-from labonneboite.common.models import CONTACT_MODE_DEFAULT
 
 logger = logging.getLogger('main')
 
@@ -153,7 +152,5 @@ def get_contact_mode_for_rome_and_naf(rome, naf):
     elif rome_to_contact_mode_dict:
         contact_mode = rome_to_contact_mode_dict.values()[0]
     else:
-        contact_mode = CONTACT_MODE_DEFAULT
+        contact_mode = settings.CONTACT_MODE_DEFAULT
     return contact_mode
-
-

--- a/labonneboite/common/util.py
+++ b/labonneboite/common/util.py
@@ -10,6 +10,7 @@ from flask import request
 from flask_login import current_user
 
 from labonneboite.conf import settings
+from labonneboite.conf.common.contact_mode import CONTACT_MODE_DEFAULT
 from labonneboite.common.load_data import load_contact_modes
 
 logger = logging.getLogger('main')
@@ -152,5 +153,5 @@ def get_contact_mode_for_rome_and_naf(rome, naf):
     elif rome_to_contact_mode_dict:
         contact_mode = rome_to_contact_mode_dict.values()[0]
     else:
-        contact_mode = settings.CONTACT_MODE_DEFAULT
+        contact_mode = CONTACT_MODE_DEFAULT
     return contact_mode

--- a/labonneboite/conf/common/contact_mode.py
+++ b/labonneboite/conf/common/contact_mode.py
@@ -1,0 +1,23 @@
+# coding: utf8
+
+# Contact modes
+CONTACT_MODE_STAGES = {
+    u"Se présenter spontanément": [
+        u"Se présenter à l'adresse indiquée avec CV et photo",
+        u"Demander le nom d'un contact pour relancer",
+        u"Relancer votre interlocuteur par téléphone",
+        u"Déclarer votre reprise d'emploi à Pôle emploi :-)",
+    ],
+    u"Envoyer un CV et une lettre de motivation": [
+        (u"Rechercher le nom d'un contact dans l'entreprise (google, kompass, linkedin, viadeo, votre réseau) "
+            u"pour lui adresser votre courrier/email"),
+        (u"Rechercher des informations économiques (projet, évolution) sur l'entreprise afin de personnaliser "
+            u"votre lettre de motivation"),
+        u"Envoyer votre CV et votre lettre de motivation",
+        u"Relancer votre interlocuteur par téléphone",
+        u"Préparer votre entretien",
+        u"Déclarer votre reprise d'emploi à Pôle emploi :-)",
+    ]
+}
+
+CONTACT_MODE_DEFAULT = u"Envoyer un CV et une lettre de motivation"

--- a/labonneboite/conf/common/settings_common.py
+++ b/labonneboite/conf/common/settings_common.py
@@ -64,27 +64,6 @@ SORT_FILTER_DEFAULT = "score"
 PAGINATION_MAX_PAGES = 10
 PAGINATION_COMPANIES_PER_PAGE = 10
 
-# Contact modes
-CONTACT_MODE_STAGES = {
-    u"Se présenter spontanément": [
-        u"Se présenter à l'adresse indiquée avec CV et photo",
-        u"Demander le nom d'un contact pour relancer",
-        u"Relancer votre interlocuteur par téléphone",
-        u"Déclarer votre reprise d'emploi à Pôle emploi :-)",
-    ],
-    u"Envoyer un CV et une lettre de motivation": [
-        (u"Rechercher le nom d'un contact dans l'entreprise (google, kompass, linkedin, viadeo, votre réseau) "
-            u"pour lui adresser votre courrier/email"),
-        (u"Rechercher des informations économiques (projet, évolution) sur l'entreprise afin de personnaliser "
-            u"votre lettre de motivation"),
-        u"Envoyer votre CV et votre lettre de motivation",
-        u"Relancer votre interlocuteur par téléphone",
-        u"Préparer votre entretien",
-        u"Déclarer votre reprise d'emploi à Pôle emploi :-)",
-    ]
-}
-CONTACT_MODE_DEFAULT = u"Envoyer un CV et une lettre de motivation"
-
 ES_INDEX = 'labonneboite'
 
 LOGSTASH_HOST = "localhost"

--- a/labonneboite/conf/common/settings_common.py
+++ b/labonneboite/conf/common/settings_common.py
@@ -64,6 +64,27 @@ SORT_FILTER_DEFAULT = "score"
 PAGINATION_MAX_PAGES = 10
 PAGINATION_COMPANIES_PER_PAGE = 10
 
+# Contact modes
+CONTACT_MODE_STAGES = {
+    u"Se présenter spontanément": [
+        u"Se présenter à l'adresse indiquée avec CV et photo",
+        u"Demander le nom d'un contact pour relancer",
+        u"Relancer votre interlocuteur par téléphone",
+        u"Déclarer votre reprise d'emploi à Pôle emploi :-)",
+    ],
+    u"Envoyer un CV et une lettre de motivation": [
+        (u"Rechercher le nom d'un contact dans l'entreprise (google, kompass, linkedin, viadeo, votre réseau) "
+            u"pour lui adresser votre courrier/email"),
+        (u"Rechercher des informations économiques (projet, évolution) sur l'entreprise afin de personnaliser "
+            u"votre lettre de motivation"),
+        u"Envoyer votre CV et votre lettre de motivation",
+        u"Relancer votre interlocuteur par téléphone",
+        u"Préparer votre entretien",
+        u"Déclarer votre reprise d'emploi à Pôle emploi :-)",
+    ]
+}
+CONTACT_MODE_DEFAULT = u"Envoyer un CV et une lettre de motivation"
+
 ES_INDEX = 'labonneboite'
 
 LOGSTASH_HOST = "localhost"

--- a/labonneboite/tests/web/api/test_api.py
+++ b/labonneboite/tests/web/api/test_api.py
@@ -637,3 +637,17 @@ class ApiCompanyListTest(ApiBaseTest):
         self.assertEqual(len(data['companies']), 1)
         self.assertEqual(data['companies'][0]['siret'], u'00000000000013')
         self.assertEqual(data['companies'][0]['headcount_text'], u'100 à 199 salariés')
+
+    def test_contact_mode(self):
+        params = self.add_security_params({
+            'commune_id': self.positions['caen']['commune_id'],
+            'rome_codes': u'D1405',
+            'user': u'labonneboite',
+        })
+        rv = self.app.get('/api/v1/company/?%s' % urlencode(params))
+        self.assertEqual(rv.status_code, 200)
+        data = json.loads(rv.data)
+        self.assertEqual(data['companies_count'], 1)
+        self.assertEqual(len(data['companies']), 1)
+        self.assertEqual(data['companies'][0]['siret'], u'00000000000004')
+        self.assertEqual(data['companies'][0]['contact_mode'], u'Envoyer un CV et une lettre de motivation')

--- a/labonneboite/web/office/views.py
+++ b/labonneboite/web/office/views.py
@@ -16,7 +16,6 @@ from flask import request, session, url_for
 from labonneboite.common import pdf as pdf_util
 from labonneboite.common import util
 from labonneboite.common.email_util import MandrillClient
-from labonneboite.common.models import CONTACT_MODE_STAGES
 from labonneboite.common.models import Office
 from labonneboite.conf import settings
 
@@ -137,7 +136,7 @@ def download(siret=None):
         dic = detail(siret)
         office = dic['company']
         pdf_target = StringIO.StringIO()
-        dic['stages'] = CONTACT_MODE_STAGES[dic['contact_mode']]
+        dic['stages'] = settings.CONTACT_MODE_STAGES[dic['contact_mode']]
         dic['date'] = date.today()
         pdf_data = render_template('office/pdf_detail.html', **dic)
         pisa.CreatePDF(StringIO.StringIO(pdf_data), pdf_target, link_callback=fetch_resources)

--- a/labonneboite/web/office/views.py
+++ b/labonneboite/web/office/views.py
@@ -18,6 +18,7 @@ from labonneboite.common import util
 from labonneboite.common.email_util import MandrillClient
 from labonneboite.common.models import Office
 from labonneboite.conf import settings
+from labonneboite.conf.common.contact_mode import CONTACT_MODE_STAGES
 
 from labonneboite.web.office.forms import OfficeRemovalForm
 
@@ -136,7 +137,7 @@ def download(siret=None):
         dic = detail(siret)
         office = dic['company']
         pdf_target = StringIO.StringIO()
-        dic['stages'] = settings.CONTACT_MODE_STAGES[dic['contact_mode']]
+        dic['stages'] = CONTACT_MODE_STAGES[dic['contact_mode']]
         dic['date'] = date.today()
         pdf_data = render_template('office/pdf_detail.html', **dic)
         pisa.CreatePDF(StringIO.StringIO(pdf_data), pdf_target, link_callback=fetch_resources)


### PR DESCRIPTION
J'ai eu un problème avec les variables CONTACT_MODE_STAGES et CONTACT_MODE_DEFAULT que je n'arrivais pas à importer...
Après, on avait des imports que je trouvais bizarre :
 - CONTACT_MODE_STAGES & CONTACT_MODE_DEFAULT étaient définis dans office.py
 - avec ma modification, office.py appelait util.py qui importait model.py qui importait lui-meme depuis office.py

Du coup, j'ai déplacé CONTACT_MODE_STAGES & CONTACT_MODE_DEFAULT dans settings_common.py pour régler mon souci d'import 