### PR TITLE
acantin/increase_commentary_size_in_contact_form

### DIFF
--- a/labonneboite/web/office/forms.py
+++ b/labonneboite/web/office/forms.py
@@ -32,4 +32,4 @@ class OfficeRemovalForm(FlaskForm):
     last_name = StringField(u'Nom *', validators=[DataRequired()])
     email = EmailField(u'Email *', validators=[DataRequired(), Email()], description="Exemple : example@domaine.com")
     phone = TelField(u'Téléphone', description="Exemples: 01 77 86 39 49, +33 1 77 86 39 49")
-    comment = TextAreaField(u'Commentaires', [validators.optional(), validators.length(max=1000)], description=u"1000 caractères maximum")
+    comment = TextAreaField(u'Commentaires', [validators.optional(), validators.length(max=15000)], description=u"15000 caractères maximum")

--- a/labonneboite/web/office/forms.py
+++ b/labonneboite/web/office/forms.py
@@ -16,19 +16,20 @@ class OfficeRemovalForm(FlaskForm):
         (u'autre', u'Autre')
     )
 
-    action = SelectField(u'Je souhaite :', choices=ACTION_CHOICES, default=u'promouvoir')
+    action = SelectField(u'Je souhaite *', choices=ACTION_CHOICES, default=u'promouvoir')
     siret = StringField(
-        u'Siret (14 chiffres)',
+        u'Siret *',
         validators=[
             DataRequired(),
             Regexp(
                 '[0-9]{10,14}',
                 message=(u"Le siret de l'établissement dont vous êtes le dirigeant est invalide (14 chiffres)")
             )
-        ]
+        ],
+        description="14 chiffres, sans espace. Exemple: 36252187900034"
     )
-    first_name = StringField(u'Prénom', validators=[DataRequired()])
-    last_name = StringField(u'Nom', validators=[DataRequired()])
-    email = EmailField(u'Email', validators=[DataRequired(), Email()])
-    phone = TelField(u'Téléphone')
-    comment = TextAreaField(u'Commentaires', [validators.optional(), validators.length(max=200)])
+    first_name = StringField(u'Prénom *', validators=[DataRequired()])
+    last_name = StringField(u'Nom *', validators=[DataRequired()])
+    email = EmailField(u'Email *', validators=[DataRequired(), Email()], description="Exemple : example@domaine.com")
+    phone = TelField(u'Téléphone', description="Exemples: 01 77 86 39 49, +33 1 77 86 39 49")
+    comment = TextAreaField(u'Commentaires', [validators.optional(), validators.length(max=1000)], description=u"1000 caractères maximum")

--- a/labonneboite/web/templates/includes/form_content.html
+++ b/labonneboite/web/templates/includes/form_content.html
@@ -17,10 +17,15 @@ If you have multiple forms, you can use the `with` statement, e.g.:
   {% endwith %}
 
 #}
+{% set aria_required = {'aria-required':'true'} %}
+
 {% for field in form if field.widget.input_type != 'hidden' %}
   <div{% if field.errors %} class="form-error"{% endif %}>
+    {% set is_required = field.validators[0].__class__.__name__ == "DataRequired"%}
+
     {{ field.label }}
-    {{ field() }}
+    {{ field(**aria_required) if is_required else field() }}
+    
     {% if field.description %}<p class="form-help-text">{{ field.description }}</p>{% endif %}
     {% if field.errors %}
     <ul class="form-errorlist">
@@ -35,5 +40,5 @@ If you have multiple forms, you can use the `with` statement, e.g.:
 {{ form.hidden_tag() }}
 
 <p>
-  <input class="btn" type="submit" value="Envoyer">
+  <input class="btn" type="submit" value="Envoyer votre demande">
 </p>

--- a/labonneboite/web/templates/office/change_info.html
+++ b/labonneboite/web/templates/office/change_info.html
@@ -8,6 +8,8 @@
 
     <h2>Demande de modification des informations de mon entreprise</h2>
 
+    <p class="text-center">Le remplissage des champs accompagnés d'une étoile '*' est obligatoire</p>
+
     <form class="form-vertical" action="" method="post">
       {% include "includes/form_content.html" %}
     </form>


### PR DESCRIPTION
La taille a été augmenté de 200 à 15 000 caractères (pour laisser une bonne marge de manoeuvre)

J'en ai profité pour améliorer l'accessibilité du formulaire (champs obligatoires et exemples)