### PR TITLE
Ensure at least 2GB of RAM for the Vagrant VM

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -77,11 +77,8 @@ Vagrant.configure(2) do |config|
   end
 
   # convert 'mem' to MB then give VM 1/4 of total system memory 
-  mem = mem / 1024 / 4
-  # Ensure at least 2 GB of RAM
-  if mem < 2048
-    mem = 2048
-  end
+  # And ensure at least 2 GB of RAM
+  mem = [mem / 1024 / 4, 2048].max
   v.customize ["modifyvm", :id, "--memory", mem]
 
   # give access to all cpu cores on the host

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -76,8 +76,8 @@ Vagrant.configure(2) do |config|
     cpus = 2
   end
 
-  # convert 'mem' to MB then give VM 1/4 of total system memory 
-  # And ensure at least 2 GB of RAM
+  # convert 'mem' from KB to MB then give VM 1/4 of total system memory 
+  # and ensure at least 2 GB of RAM
   mem = [mem / 1024 / 4, 2048].max
   v.customize ["modifyvm", :id, "--memory", mem]
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -78,6 +78,10 @@ Vagrant.configure(2) do |config|
 
   # convert 'mem' to MB then give VM 1/4 of total system memory 
   mem = mem / 1024 / 4
+  # Ensure at least 2 GB of RAM
+  if mem < 2048
+    mem = 2048
+  end
   v.customize ["modifyvm", :id, "--memory", mem]
 
   # give access to all cpu cores on the host


### PR DESCRIPTION
Avec 1GB de RAM, on ne peut pas démarrer ElasticSearch (qui a besoin d'1Giga de RAM)
De même, pip install a aussi des soucis de mémoire...

Du coup, j'ai fait en sorte d'imposer qu'on ait 2 Go de RAM minimum pour la VM via le VagantFile.