### PR TITLE
Regisb/improve unittests

### DIFF
--- a/labonneboite/importer/jobs/check_dpae.py
+++ b/labonneboite/importer/jobs/check_dpae.py
@@ -1,17 +1,10 @@
-import logging
-logger = logging.getLogger('main')
-formatter = logging.Formatter("%(levelname)s - IMPORTER - %(message)s")
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-
 import sys
 import os
 
 from labonneboite.importer import settings
 from labonneboite.importer import util as import_util
 from labonneboite.importer.util import parse_dpae_line
+from .common import logger
 
 def get_n_lines(path, n=5, ignore_header=True):
     results = []

--- a/labonneboite/importer/jobs/check_etablissements.py
+++ b/labonneboite/importer/jobs/check_etablissements.py
@@ -1,15 +1,7 @@
-import logging
-logger = logging.getLogger('main')
-formatter = logging.Formatter("%(levelname)s - IMPORTER - %(message)s")
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-
 import sys
 import os
 from labonneboite.importer import util as import_util
-
+from .common import logger
 
 if __name__ == "__main__":
     filename = import_util.detect_runnable_file("etablissements")

--- a/labonneboite/importer/jobs/common.py
+++ b/labonneboite/importer/jobs/common.py
@@ -1,0 +1,10 @@
+import logging
+
+__all__ = ['logger']
+
+logger = logging.getLogger('main')
+formatter = logging.Formatter("%(levelname)s - IMPORTER - %(message)s")
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler()
+handler.setFormatter(formatter)
+logger.addHandler(handler)

--- a/labonneboite/importer/jobs/compute_scores.py
+++ b/labonneboite/importer/jobs/compute_scores.py
@@ -20,15 +20,8 @@ from labonneboite.importer import settings
 from labonneboite.importer import compute_score
 from labonneboite.importer import util as import_util
 from labonneboite.importer.models.computing import DpaeStatistics
-from labonneboite.importer.jobs.base import Job
-
-
-logger = logging.getLogger('main')
-formatter = logging.Formatter("%(levelname)s - IMPORTER - %(message)s")
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-logger.addHandler(handler)
+from .base import Job
+from .common import logger
 
 COMPUTE_SCORE_TIMEOUT = 3600 * 8  # computing scores for 75 might take 4h+
 

--- a/labonneboite/importer/jobs/extract_dpae.py
+++ b/labonneboite/importer/jobs/extract_dpae.py
@@ -15,17 +15,9 @@ from sqlalchemy.exc import OperationalError
 from labonneboite.importer import settings
 from labonneboite.importer import util as import_util
 from labonneboite.importer.util import parse_dpae_line, DepartementException, TooFewFieldsException
-from base import Job
 from labonneboite.importer.models.computing import DpaeStatistics, ImportTask
-
-import logging
-
-logger = logging.getLogger('main')
-formatter = logging.Formatter("%(levelname)s - IMPORTER - %(message)s")
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-logger.addHandler(handler)
+from .base import Job
+from .common import logger
 
 
 class DpaeExtractJob(Job):

--- a/labonneboite/importer/jobs/extract_etablissements.py
+++ b/labonneboite/importer/jobs/extract_etablissements.py
@@ -9,16 +9,8 @@ from labonneboite.importer import settings
 from labonneboite.importer import util as import_util
 from labonneboite.importer.models.computing import ImportTask
 from labonneboite.common import encoding as encoding_util
-from base import Job
-
-import logging
-
-logger = logging.getLogger('main')
-formatter = logging.Formatter("%(levelname)s - IMPORTER - %(message)s")
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-logger.addHandler(handler)
+from .base import Job
+from .common import logger
 
 
 class DepartementException(Exception):

--- a/labonneboite/importer/jobs/geocode.py
+++ b/labonneboite/importer/jobs/geocode.py
@@ -5,15 +5,6 @@ This module assists in finding and assigning geo coordinates to etablissements.
 
 """
 
-import logging
-
-logger = logging.getLogger('main')
-formatter = logging.Formatter("%(levelname)s - IMPORTER - %(message)s")
-logger.setLevel(logging.INFO)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-
 from labonneboite.common.database import db_session
 
 import gevent.monkey
@@ -38,12 +29,10 @@ CITY_NAMES = load_city_codes()
 from labonneboite.importer import settings
 from labonneboite.importer import util as import_util
 from labonneboite.importer.models.computing import Geolocation
-from base import Job
+from .base import Job
+from .common import logger
 
 from sqlalchemy.exc import IntegrityError
-
-import logging
-logger = logging.getLogger('main')
 
 
 class IncorrectAdressDataException(Exception):

--- a/labonneboite/importer/jobs/populate_flags.py
+++ b/labonneboite/importer/jobs/populate_flags.py
@@ -8,14 +8,8 @@ from datetime import datetime
 from labonneboite.importer import util as import_util
 from labonneboite.importer import settings
 from labonneboite.importer.models.computing import ImportTask
-from base import Job
-
-logger = logging.getLogger('main')
-formatter = logging.Formatter("%(levelname)s - IMPORTER - %(message)s")
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-logger.addHandler(handler)
+from .base import Job
+from .common import logger
 
 
 def populate_flags():

--- a/labonneboite/importer/jobs/validate_scores.py
+++ b/labonneboite/importer/jobs/validate_scores.py
@@ -3,16 +3,8 @@
 Validates scoring data produced by compute_scores.
 """
 
-import logging
-
-logger = logging.getLogger('main')
-formatter = logging.Formatter("%(levelname)s - IMPORTER - %(message)s")
-logger.setLevel(logging.DEBUG)
-handler = logging.StreamHandler()
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-
 from labonneboite.importer import sanity
+from .common import logger
 
 COMPUTE_SCORE_TIMEOUT = 3600 * 4  # four hours should be largely enough to compute scores for an entire departement
 

--- a/labonneboite/importer/tests/test_base.py
+++ b/labonneboite/importer/tests/test_base.py
@@ -4,6 +4,7 @@ import unittest
 from labonneboite.common.database import db_session, init_db, delete_db, engine
 
 from labonneboite.importer import settings as importer_settings
+from labonneboite.importer.jobs.common import logger
 
 importer_settings.INPUT_SOURCE_FOLDER = os.path.join(os.path.dirname(__file__), 'data')
 importer_settings.MIN_DPAE_COUNT_PER_DAY = 0
@@ -28,6 +29,10 @@ class DatabaseTest(unittest.TestCase):
         engine.dispose()
         delete_db()
         init_db()
+
+        # Mute jobs logger
+        logger.setLevel('CRITICAL')
+
 
         return super(DatabaseTest, self).setUp()
 

--- a/labonneboite/tests/test_base.py
+++ b/labonneboite/tests/test_base.py
@@ -107,6 +107,7 @@ class DatabaseTest(AppTest):
     def setUp(self):
 
         # Create MySQL tables.
+        delete_db()
         init_db()
 
         # Create ES index.

--- a/labonneboite/tests/test_base.py
+++ b/labonneboite/tests/test_base.py
@@ -1,4 +1,5 @@
 # coding: utf8
+import logging
 import unittest
 
 from elasticsearch import Elasticsearch
@@ -40,6 +41,8 @@ class AppTest(unittest.TestCase):
         self.app = app.test_client()
         self.app_context = app.app_context()
         self.test_request_context = app.test_request_context()
+        # Disable logging
+        app.logger.setLevel(logging.CRITICAL)
         return super(AppTest, self).setUp()
 
     def url_for(self, endpoint, **kwargs):


### PR DESCRIPTION
Je suis un grand fan des tests silencieux qui n'affichent rien (ou presque) dans la console. Actuellement, quand on lance les tests en local c'est difficile de remonter l'historique des tests qui échouent. Avec ces changements on y voit plus clair (IMHO).

J'ai aussi inséré la suppression d'une db au lancement des test d'intégration après m'être retrouvé dans un état où les tests ne fonctionnaient plus parce que la db ne pouvait pas être initialisée.