### PR TITLE
Regisb/fix unicodeerror urlencode

### DIFF
--- a/labonneboite/tests/web/integration/test_pagination.py
+++ b/labonneboite/tests/web/integration/test_pagination.py
@@ -1,7 +1,7 @@
 # coding: utf8
 import unittest
 
-from labonneboite.web.pagination import PaginationManager
+from labonneboite.web.pagination import Page, PaginationManager
 
 
 class PaginationTest(unittest.TestCase):
@@ -17,3 +17,11 @@ class PaginationTest(unittest.TestCase):
         pm = PaginationManager(company_count, 1, 10, "")
         pm.get_pages()
         self.assertEquals(2, pm.get_page_count())
+
+
+class PageTest(unittest.TestCase):
+
+    def test_unicode_url(self):
+        original_url = u'/pouac?h=1l%C3%A0' # h=1là (observed in production)
+        page = Page(1, 1, 1, original_url)
+        self.assertEqual('/pouac?h=1l%C3%A0&from=11&to=1', page.get_url())

--- a/labonneboite/web/pagination.py
+++ b/labonneboite/web/pagination.py
@@ -68,9 +68,7 @@ class PaginationManager(object):
     def _run(self):
         min_page, max_page = self.get_lower_and_upper_pages()
         for ranking in range(min_page, max_page):
-            url_parts = list(urlparse.urlparse(self.full_path_url))
-            page = Page(ranking, self.company_count, self.current_from_number,
-                        url_parts)
+            page = self._get_page(ranking)
             self.pages.append(page)
 
     def should_show(self):
@@ -121,29 +119,24 @@ class PaginationManager(object):
         return max_page < self.get_page_count()
 
     def get_first_page(self):
-        ranking = 0
-        url_parts = list(urlparse.urlparse(self.full_path_url))
-        page = Page(ranking, self.company_count, self.current_from_number,
-                    url_parts)
-        return page
+        return self._get_page(0)
 
     def get_last_page(self):
-        ranking = self.get_page_count() - 1
-        url_parts = list(urlparse.urlparse(self.full_path_url))
-        page = Page(ranking, self.company_count, self.current_from_number,
-                    url_parts)
-        return page
+        return self._get_page(self.get_page_count() - 1)
+
+    def _get_page(self, ranking):
+        return Page(ranking, self.company_count, self.current_from_number, self.full_path_url)
 
 
 class Page(object):
 
-    def __init__(self, ranking, company_count, current_from_number, url_parts):
+    def __init__(self, ranking, company_count, current_from_number, original_url):
         self.ranking = ranking
         self.company_count = company_count
         self._from_number = None
         self._to_number = None
-        self.url_parts = url_parts
         self.current_from_number = current_from_number
+        self.url_parts = list(urlparse.urlparse(original_url))
 
     def get_from_number(self):
         if not self._from_number:

--- a/labonneboite/web/pagination.py
+++ b/labonneboite/web/pagination.py
@@ -136,7 +136,7 @@ class Page(object):
         self._from_number = None
         self._to_number = None
         self.current_from_number = current_from_number
-        self.url_parts = list(urlparse.urlparse(original_url))
+        self.url_parts = list(urlparse.urlparse(original_url.encode('utf8')))
 
     def get_from_number(self):
         if not self._from_number:


### PR DESCRIPTION
 Unicode parameters accidentally (or not...) passed in the url were causing a call to urlencode to fail.

J'en ai profité pour simplifier la manière dont un objet `Page` est construit.