### PR TITLE
Fix UnicodeDecodeError due to url not in unicode

### DIFF
--- a/labonneboite/tests/web/integration/test_pagination.py
+++ b/labonneboite/tests/web/integration/test_pagination.py
@@ -21,7 +21,12 @@ class PaginationTest(unittest.TestCase):
 
 class PageTest(unittest.TestCase):
 
-    def test_unicode_url(self):
+    def test_unicode_query_parameter(self):
         original_url = u'/pouac?h=1l%C3%A0' # h=1là (observed in production)
         page = Page(1, 1, 1, original_url)
         self.assertEqual('/pouac?h=1l%C3%A0&from=11&to=1', page.get_url())
+
+    def test_page_url_is_unicode(self):
+        original_url = u'/nîmes' # (observed in production)
+        page = Page(1, 1, 1, original_url)
+        self.assertEqual('/nîmes?to=1&from=11', page.get_url().encode('utf8'))

--- a/labonneboite/web/pagination.py
+++ b/labonneboite/web/pagination.py
@@ -131,6 +131,13 @@ class PaginationManager(object):
 class Page(object):
 
     def __init__(self, ranking, company_count, current_from_number, original_url):
+        """
+        Args:
+            ranking (int)
+            company_count (int)
+            current_from_number (int)
+            original_url (unicode)
+        """
         self.ranking = ranking
         self.company_count = company_count
         self._from_number = None
@@ -152,9 +159,13 @@ class Page(object):
         return self.get_from_number() == self.current_from_number
 
     def get_url(self):
+        """
+        Returns:
+            page_url (unicode)
+        """
         params = {'from': self.get_from_number(), 'to': self.get_to_number()}
         url_query = dict(urlparse.parse_qsl(self.url_parts[4]))
         url_query.update(params)
         self.url_parts[4] = urlencode(url_query)
         page_url = urlparse.urlunparse(self.url_parts)
-        return page_url
+        return page_url.decode('utf8')


### PR DESCRIPTION
When we write "{{ x }}" in a jinja2 template, x is expected to be of
unicode type, or convertible to unicode. The issue we had here was that
the result of `page.get_url` was str, and not unicode. This raised
UnicodeDecodeError.