### PR TITLE
Handle more auth_social exceptions

### DIFF
--- a/labonneboite/web/app.py
+++ b/labonneboite/web/app.py
@@ -331,8 +331,9 @@ def social_auth_error(error):
     """
     Handle the situation where a user clicks the `cancel` button on a third party auth provider website.
     """
-    if type(error).__name__ in ["AuthFailed", "AuthCanceled", "AuthStateMissing"]:
+    if isinstance(error, (AuthCanceled, AuthFailed, AuthStateMissing)):
         flash(u"Une erreur est survenue lors de votre connexion. Veuillez réessayer", 'error')
+        app.logger.warn("PEAM error: %s", error)
 
     # If there us a next url in session and it's safe, redirect to it.
     next_url = session.get('next')


### PR DESCRIPTION
Je n'ai fait que catcher les exceptions pour afficher un message à l'utilisateur

Toute la partie openIDConnect est faite avec Python-Social-Auth et, côté applicatif, c'est surtout de la configuration...

Je pense donc que les erreurs viennent de PEAM et qu'on ne gérait juste pas ces erreurs : 

- URL : https://labonneboite.pole-emploi.fr/authorize/complete/peam-openidconnect/
- Method GET
- Query 'error=server_error&state=M0foRzu8PXRQLL4yTuBOSUP3iCEFMnv7&error_description=Could+not+create+token+in+CTS'

