### PR TITLE
Acantin/suggest action in contact mail

### DIFF
--- a/labonneboite/tests/app/test_contact_form_suggestions.py
+++ b/labonneboite/tests/app/test_contact_form_suggestions.py
@@ -40,7 +40,7 @@ class SaveSuggestionsTest(CreateIndexBaseTest):
             form.siret = StringField(u'Siret')
             form.siret.data = u"12345678901234"
 
-            url = '%s?id=%s' % (url_for("officeadminremove.edit_view"), 1)
+            url = url_for("officeadminremove.edit_view", id=1)
             expected_text = u"Entreprise retirée via Save : <a href='%s'>Voir la fiche de suppression</a>" % url
 
             self.assertEquals(expected_text, make_save_suggestion(form))
@@ -80,7 +80,7 @@ class SaveSuggestionsTest(CreateIndexBaseTest):
             form.siret = StringField(u'Siret')
             form.siret.data = u"78548035101646"
 
-            url = '%s?id=%s' % (url_for("officeadminadd.edit_view"), office_admin_add.id)
+            url = url_for("officeadminadd.edit_view", id=office_admin_add.id)
             expected_text = u"Entreprise créée via Save : <a href='%s'>Voir la fiche d'ajout</a>" % url
 
             self.assertEquals(expected_text, make_save_suggestion(form))
@@ -101,7 +101,7 @@ class SaveSuggestionsTest(CreateIndexBaseTest):
             form.siret = StringField(u'Siret')
             form.siret.data = u"78548035101646"
 
-            url = '%s?id=%s' % (url_for("officeadminupdate.edit_view"), office_to_update.id)
+            url = url_for("officeadminupdate.edit_view", id=office_to_update.id)
             expected_text = u"Entreprise modifiée via Save : <a href='%s'>Voir la fiche de modification</a>" % url
 
             self.assertEquals(expected_text, make_save_suggestion(form))
@@ -109,62 +109,11 @@ class SaveSuggestionsTest(CreateIndexBaseTest):
     # Company exists and no OfficeAdmin found and the user ask for a delete
     def test_company_and_no_office_admin_and_ask_remove(self):
         with self.test_request_context:
-            # Create office
-            office = Office(
-                siret=u"78548035101648",
-                company_name=u"Test company",
-                office_name=u"Test company",
-                naf=u"4711D",
-                street_number=u"45",
-                street_name=u"AVENUE ANDRE MALRAUX",
-                city_code=u"57463",
-                zipcode=u"57000",
-                email=u"test@match.com",
-                tel=u"0387787878",
-                website=u"http://www.dummy.fr",
-                flag_alternance=0,
-                flag_junior=0,
-                flag_senior=0,
-                flag_handicap=0,
-                departement=u"57",
-                headcount=u"12",
-                score=90,
-                x=6.17952,
-                y=49.1044,
-            )
+            office = self.create_office()
             office.save()
 
-            # Create form
-            form = OfficeRemovalForm()
-            form.siret = StringField(u'Siret')
-            form.action = SelectField(u'Je souhaite *')
-            form.name = StringField(u"Nom de l'entreprise")
-            form.email = EmailField(u'Email')
-            form.first_name = StringField(u'Prénom')
-            form.last_name = StringField(u'Nom')
-            form.phone = TelField(u'Téléphone')
-            form.comment = TextAreaField(u'Raison')
-
-            # Set form values
-            form.siret.data = u"78548035101648"
-            form.name.data = u"Test company"
-            form.email.data = u"test@mail.com"
-            form.first_name.data = u"firstName"
-            form.last_name.data = u"lastName"
-            form.phone.data = u"010000000"
-            form.comment.data = u"Raison"
-            form.action.data = u"enlever" # Ask to remove the company
-
-            # Prepare expected URL
-            params = {
-                'siret': form.siret.data,
-                'name': form.name.data,
-                'requested_by_email': form.email.data,
-                'requested_by_first_name': form.first_name.data,
-                'requested_by_last_name': form.last_name.data,
-                'requested_by_phone': form.phone.data,
-                'reason': form.comment.data,
-            }
+            form = self.create_form(u'enlever')
+            params = self.create_params(form)
 
             url = '%s?%s' % (url_for("officeadminremove.create_view"), urlencode(params))
             expected_text = u" Une suppression a été demandée : <a href='%s'>Créer une fiche de suppression</a>" % url
@@ -174,64 +123,73 @@ class SaveSuggestionsTest(CreateIndexBaseTest):
     # Company exists and no OfficeAdmin found : suggest officeAdminAdd
     def test_company_and_no_office_admin(self):
         with self.test_request_context:
-            # Create office
-            office = Office(
-                siret=u"78548035101648",
-                company_name=u"Test company",
-                office_name=u"Test company",
-                naf=u"4711D",
-                street_number=u"45",
-                street_name=u"AVENUE ANDRE MALRAUX",
-                city_code=u"57463",
-                zipcode=u"57000",
-                email=u"test@match.com",
-                tel=u"0387787878",
-                website=u"http://www.dummy.fr",
-                flag_alternance=0,
-                flag_junior=0,
-                flag_senior=0,
-                flag_handicap=0,
-                departement=u"57",
-                headcount=u"12",
-                score=90,
-                x=6.17952,
-                y=49.1044,
-            )
+            office = self.create_office()
             office.save()
 
-            # Create form
-            form = OfficeRemovalForm()
-            form.siret = StringField(u'Siret')
-            form.action = SelectField(u'Je souhaite *')
-            form.name = StringField(u"Nom de l'entreprise")
-            form.email = EmailField(u'Email')
-            form.first_name = StringField(u'Prénom')
-            form.last_name = StringField(u'Nom')
-            form.phone = TelField(u'Téléphone')
-            form.comment = TextAreaField(u'Raison')
-
-            # Set form values
-            form.siret.data = u"78548035101648"
-            form.name.data = u"Test company"
-            form.email.data = u"test@mail.com"
-            form.first_name.data = u"firstName"
-            form.last_name.data = u"lastName"
-            form.phone.data = u"010000000"
-            form.comment.data = u"Raison"
-            form.action.data = u"" # No specific value
-
-            # Prepare expected URL
-            params = {
-                'siret': form.siret.data,
-                'name': form.name.data,
-                'requested_by_email': form.email.data,
-                'requested_by_first_name': form.first_name.data,
-                'requested_by_last_name': form.last_name.data,
-                'requested_by_phone': form.phone.data,
-                'reason': form.comment.data,
-            }
+            form = self.create_form()
+            params = self.create_params(form)
 
             url = '%s?%s' % (url_for("officeadminupdate.create_view"), urlencode(params))
             expected_text = u"Entreprise non modifiée via Save : <a href='%s'>Créer une fiche de modification</a>" % url
 
             self.assertEquals(expected_text, make_save_suggestion(form))
+
+
+    # Create a valid
+    def create_form(self, action=u''):
+        form = OfficeRemovalForm()
+        form.siret = StringField(u'Siret')
+        form.action = SelectField(u'Je souhaite *')
+        form.name = StringField(u"Nom de l'entreprise")
+        form.email = EmailField(u'Email')
+        form.first_name = StringField(u'Prénom')
+        form.last_name = StringField(u'Nom')
+        form.phone = TelField(u'Téléphone')
+        form.comment = TextAreaField(u'Raison')
+
+        # Set form values
+        form.siret.data = u"78548035101648"
+        form.name.data = u"Test company"
+        form.email.data = u"test@mail.com"
+        form.first_name.data = u"firstName"
+        form.last_name.data = u"lastName"
+        form.phone.data = u"010000000"
+        form.comment.data = u"Raison"
+        form.action.data = action
+
+        return form
+
+    def create_params(self, form):
+        return {
+            'siret': form.siret.data,
+            'name': form.name.data,
+            'requested_by_email': form.email.data,
+            'requested_by_first_name': form.first_name.data,
+            'requested_by_last_name': form.last_name.data,
+            'requested_by_phone': form.phone.data,
+            'reason': form.comment.data,
+        }
+
+    def create_office(self):
+        return Office(
+            siret=u"78548035101648",
+            company_name=u"Test company",
+            office_name=u"Test company",
+            naf=u"4711D",
+            street_number=u"45",
+            street_name=u"AVENUE ANDRE MALRAUX",
+            city_code=u"57463",
+            zipcode=u"57000",
+            email=u"test@match.com",
+            tel=u"0387787878",
+            website=u"http://www.dummy.fr",
+            flag_alternance=0,
+            flag_junior=0,
+            flag_senior=0,
+            flag_handicap=0,
+            departement=u"57",
+            headcount=u"12",
+            score=90,
+            x=6.17952,
+            y=49.1044,
+        )

--- a/labonneboite/tests/app/test_contact_form_suggestions.py
+++ b/labonneboite/tests/app/test_contact_form_suggestions.py
@@ -1,16 +1,237 @@
 # coding: utf8
 
 from flask import url_for
-from labonneboite.tests.test_base import DatabaseTest
+
+from wtforms import StringField, SelectField, TextAreaField
+from wtforms.fields.html5 import EmailField, TelField
+from urllib import urlencode
+
 from labonneboite.common.models import Office, OfficeAdminAdd, OfficeAdminRemove, OfficeAdminUpdate
 from labonneboite.tests.scripts.test_create_index import CreateIndexBaseTest
 from labonneboite.web.office.views import make_save_suggestion
-
+from labonneboite.web.office.forms import OfficeRemovalForm
 
 class SaveSuggestionsTest(CreateIndexBaseTest):
+    # No company and no OfficeAdminRemove
     def test_no_company_found(self):
-        # No company and no OfficeAdminRemove
-        form = {
-            'siret': u'Invalid'
-        }
-        self.assertEquals(u'Aucune entreprise trouvée avec le siret Invalid', make_save_suggestion(form))
+        with self.test_request_context:
+            # Create form
+            form = OfficeRemovalForm()
+            form.siret = StringField(u'Siret')
+            form.siret.data = u"Invalid"
+
+            self.assertEquals(u'Aucune entreprise trouvée avec le siret Invalid', make_save_suggestion(form))
+
+    # No company due to an OfficeAdminRemove
+    def test_no_company_and_remove_office(self):
+        with self.test_request_context:
+            # Create OfficeAdminRemove
+            office_to_remove = OfficeAdminRemove(
+                id=1,
+                siret=u'12345678901234',
+                name=self.office.company_name,
+                reason=u"N/A",
+                initiative=u'office',
+            )
+            office_to_remove.save(commit=True)
+
+            # Create form
+            form = OfficeRemovalForm()
+            form.siret = StringField(u'Siret')
+            form.siret.data = u"12345678901234"
+
+            url = '%s?id=%s' % (url_for("officeadminremove.edit_view"), 1)
+            expected_text = u"Entreprise retirée via Save : <a href='%s'>Voir la fiche de suppression</a>" % url
+
+            self.assertEquals(expected_text, make_save_suggestion(form))
+
+    # Company exists due to OfficeAdminAdd
+    def test_company_and_office_admin_add(self):
+        with self.test_request_context:
+            # Create OfficeAdminAdd
+            office_admin_add = OfficeAdminAdd(
+                id=1,
+                siret=u"78548035101646",
+                company_name=u"SUPERMARCHES MATCH",
+                office_name=u"SUPERMARCHES MATCH",
+                naf=u"4711D",
+                street_number=u"45",
+                street_name=u"AVENUE ANDRE MALRAUX",
+                city_code=u"57463",
+                zipcode=u"57000",
+                email=u"supermarche@match.com",
+                tel=u"0387787878",
+                website=u"http://www.supermarchesmatch.fr",
+                flag_alternance=0,
+                flag_junior=0,
+                flag_senior=0,
+                flag_handicap=0,
+                departement=u"57",
+                headcount=u"12",
+                score=90,
+                x=6.17952,
+                y=49.1044,
+                reason=u"Demande de mise en avant",
+            )
+            office_admin_add.save(commit=True)
+
+            # Create form
+            form = OfficeRemovalForm()
+            form.siret = StringField(u'Siret')
+            form.siret.data = u"78548035101646"
+
+            url = '%s?id=%s' % (url_for("officeadminadd.edit_view"), office_admin_add.id)
+            expected_text = u"Entreprise créée via Save : <a href='%s'>Voir la fiche d'ajout</a>" % url
+
+            self.assertEquals(expected_text, make_save_suggestion(form))
+
+    # Company exists and has been modified by OfficeAdminUpdate
+    def test_company_and_office_admin_update(self):
+        with self.test_request_context:
+            # Create OfficeAdminUpdate
+            office_to_update = OfficeAdminUpdate(
+                id=1,
+                siret=u"78548035101646",
+                name=u"SUPERMARCHES MATCH"
+            )
+            office_to_update.save(commit=True)
+
+            # Create form
+            form = OfficeRemovalForm()
+            form.siret = StringField(u'Siret')
+            form.siret.data = u"78548035101646"
+
+            url = '%s?id=%s' % (url_for("officeadminupdate.edit_view"), office_to_update.id)
+            expected_text = u"Entreprise modifiée via Save : <a href='%s'>Voir la fiche de modification</a>" % url
+
+            self.assertEquals(expected_text, make_save_suggestion(form))
+
+    # Company exists and no OfficeAdmin found and the user ask for a delete
+    def test_company_and_no_office_admin_and_ask_remove(self):
+        with self.test_request_context:
+            # Create office
+            office = Office(
+                siret=u"78548035101648",
+                company_name=u"Test company",
+                office_name=u"Test company",
+                naf=u"4711D",
+                street_number=u"45",
+                street_name=u"AVENUE ANDRE MALRAUX",
+                city_code=u"57463",
+                zipcode=u"57000",
+                email=u"test@match.com",
+                tel=u"0387787878",
+                website=u"http://www.dummy.fr",
+                flag_alternance=0,
+                flag_junior=0,
+                flag_senior=0,
+                flag_handicap=0,
+                departement=u"57",
+                headcount=u"12",
+                score=90,
+                x=6.17952,
+                y=49.1044,
+            )
+            office.save()
+
+            # Create form
+            form = OfficeRemovalForm()
+            form.siret = StringField(u'Siret')
+            form.action = SelectField(u'Je souhaite *')
+            form.name = StringField(u"Nom de l'entreprise")
+            form.email = EmailField(u'Email')
+            form.first_name = StringField(u'Prénom')
+            form.last_name = StringField(u'Nom')
+            form.phone = TelField(u'Téléphone')
+            form.comment = TextAreaField(u'Raison')
+
+            # Set form values
+            form.siret.data = u"78548035101648"
+            form.name.data = u"Test company"
+            form.email.data = u"test@mail.com"
+            form.first_name.data = u"firstName"
+            form.last_name.data = u"lastName"
+            form.phone.data = u"010000000"
+            form.comment.data = u"Raison"
+            form.action.data = u"enlever" # Ask to remove the company
+
+            # Prepare expected URL
+            params = {
+                'siret': form.siret.data,
+                'name': form.name.data,
+                'requested_by_email': form.email.data,
+                'requested_by_first_name': form.first_name.data,
+                'requested_by_last_name': form.last_name.data,
+                'requested_by_phone': form.phone.data,
+                'reason': form.comment.data,
+            }
+
+            url = '%s?%s' % (url_for("officeadminremove.create_view"), urlencode(params))
+            expected_text = u" Une suppression a été demandée : <a href='%s'>Créer une fiche de suppression</a>" % url
+
+            self.assertEquals(expected_text, make_save_suggestion(form))
+
+    # Company exists and no OfficeAdmin found : suggest officeAdminAdd
+    def test_company_and_no_office_admin(self):
+        with self.test_request_context:
+            # Create office
+            office = Office(
+                siret=u"78548035101648",
+                company_name=u"Test company",
+                office_name=u"Test company",
+                naf=u"4711D",
+                street_number=u"45",
+                street_name=u"AVENUE ANDRE MALRAUX",
+                city_code=u"57463",
+                zipcode=u"57000",
+                email=u"test@match.com",
+                tel=u"0387787878",
+                website=u"http://www.dummy.fr",
+                flag_alternance=0,
+                flag_junior=0,
+                flag_senior=0,
+                flag_handicap=0,
+                departement=u"57",
+                headcount=u"12",
+                score=90,
+                x=6.17952,
+                y=49.1044,
+            )
+            office.save()
+
+            # Create form
+            form = OfficeRemovalForm()
+            form.siret = StringField(u'Siret')
+            form.action = SelectField(u'Je souhaite *')
+            form.name = StringField(u"Nom de l'entreprise")
+            form.email = EmailField(u'Email')
+            form.first_name = StringField(u'Prénom')
+            form.last_name = StringField(u'Nom')
+            form.phone = TelField(u'Téléphone')
+            form.comment = TextAreaField(u'Raison')
+
+            # Set form values
+            form.siret.data = u"78548035101648"
+            form.name.data = u"Test company"
+            form.email.data = u"test@mail.com"
+            form.first_name.data = u"firstName"
+            form.last_name.data = u"lastName"
+            form.phone.data = u"010000000"
+            form.comment.data = u"Raison"
+            form.action.data = u"" # No specific value
+
+            # Prepare expected URL
+            params = {
+                'siret': form.siret.data,
+                'name': form.name.data,
+                'requested_by_email': form.email.data,
+                'requested_by_first_name': form.first_name.data,
+                'requested_by_last_name': form.last_name.data,
+                'requested_by_phone': form.phone.data,
+                'reason': form.comment.data,
+            }
+
+            url = '%s?%s' % (url_for("officeadminupdate.create_view"), urlencode(params))
+            expected_text = u"Entreprise non modifiée via Save : <a href='%s'>Créer une fiche de modification</a>" % url
+
+            self.assertEquals(expected_text, make_save_suggestion(form))

--- a/labonneboite/tests/app/test_contact_form_suggestions.py
+++ b/labonneboite/tests/app/test_contact_form_suggestions.py
@@ -1,0 +1,16 @@
+# coding: utf8
+
+from flask import url_for
+from labonneboite.tests.test_base import DatabaseTest
+from labonneboite.common.models import Office, OfficeAdminAdd, OfficeAdminRemove, OfficeAdminUpdate
+from labonneboite.tests.scripts.test_create_index import CreateIndexBaseTest
+from labonneboite.web.office.views import make_save_suggestion
+
+
+class SaveSuggestionsTest(CreateIndexBaseTest):
+    def test_no_company_found(self):
+        # No company and no OfficeAdminRemove
+        form = {
+            'siret': u'Invalid'
+        }
+        self.assertEquals(u'Aucune entreprise trouvée avec le siret Invalid', make_save_suggestion(form))

--- a/labonneboite/web/admin/views/office_admin_remove.py
+++ b/labonneboite/web/admin/views/office_admin_remove.py
@@ -1,5 +1,5 @@
 # coding: utf8
-from flask import flash, url_for
+from flask import flash, request, url_for
 from flask import Markup
 from flask_admin.contrib.sqla import ModelView
 from wtforms import validators
@@ -121,6 +121,25 @@ class OfficeAdminRemoveModelView(AdminModelViewMixin, ModelView):
             'validators': [validators.optional(), phone_validator],
         },
     }
+
+    def create_form(self):
+        form = super(OfficeAdminRemoveModelView, self).create_form()
+        if 'siret' in request.args:
+            form.siret.data = request.args['siret']
+        if 'name' in request.args:
+            form.name.data = request.args['name']
+        if 'requested_by_email' in request.args:
+            form.requested_by_email.data = request.args['requested_by_email']
+        if 'requested_by_first_name' in request.args:
+            form.requested_by_first_name.data = request.args['requested_by_first_name']
+        if 'requested_by_last_name' in request.args:
+            form.requested_by_last_name.data = request.args['requested_by_last_name']
+        if 'requested_by_phone' in request.args:
+            form.requested_by_phone.data = request.args['requested_by_phone']
+        if 'reason' in request.args:
+            form.reason.data = request.args['reason']
+
+        return form
 
     def validate_form(self, form):
         """

--- a/labonneboite/web/admin/views/office_admin_update.py
+++ b/labonneboite/web/admin/views/office_admin_update.py
@@ -1,5 +1,5 @@
 # coding: utf8
-from flask import flash
+from flask import flash, request
 from flask import Markup
 from flask_admin.contrib.sqla import ModelView
 from wtforms import validators
@@ -173,9 +173,27 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         },
     }
 
+    def create_form(self):
+        form = super(OfficeAdminUpdateModelView, self).create_form()
+        if 'siret' in request.args:
+            form.siret.data = request.args['siret']
+        if 'name' in request.args:
+            form.name.data = request.args['name']
+        if 'requested_by_email' in request.args:
+            form.requested_by_email.data = request.args['requested_by_email']
+        if 'requested_by_first_name' in request.args:
+            form.requested_by_first_name.data = request.args['requested_by_first_name']
+        if 'requested_by_last_name' in request.args:
+            form.requested_by_last_name.data = request.args['requested_by_last_name']
+        if 'requested_by_phone' in request.args:
+            form.requested_by_phone.data = request.args['requested_by_phone']
+        if 'reason' in request.args:
+            form.reason.data = request.args['reason']
+
+        return form
+
     def validate_form(self, form):
         is_valid = super(OfficeAdminUpdateModelView, self).validate_form(form)
-
         # Codes ROMES to boost or to add
         if is_valid and form.data.get('romes_to_boost'):
 

--- a/labonneboite/web/office/forms.py
+++ b/labonneboite/web/office/forms.py
@@ -10,9 +10,9 @@ from wtforms.validators import DataRequired, Email, Regexp
 class OfficeRemovalForm(FlaskForm):
 
     ACTION_CHOICES = (
-        (u'promouvoir', u'Que mon entreprise soit davantage mise en avant'),
-        (u'enlever', u'Supprimer mon entreprise des résultats'),
-        (u'modifier', u'Mettre à jour les informations de mon entreprise'),
+        (u'promouvoir', u'Promouvoir mon entreprise sur le site'),
+        (u'enlever', u'Retirer mon entreprise du site'),
+        (u'modifier', u'Modifier les coordonnées de mon entreprise sur le site'),
         (u'autre', u'Autre')
     )
 

--- a/labonneboite/web/office/views.py
+++ b/labonneboite/web/office/views.py
@@ -122,26 +122,26 @@ def detail(siret):
 
 def make_save_suggestion(form):
     # Save informations
-    company = Office.query.filter(Office.siret == form.siret.data).first()
+    company = Office.query.filter_by(siret = form.siret.data).first()
     if not company:
         # OfficeAdminRemove already exits ?
-        office_admin_remove = OfficeAdminRemove.query.filter(OfficeAdminRemove.siret == form.siret.data).first()
+        office_admin_remove = OfficeAdminRemove.query.filter_by(siret = form.siret.data).first()
         if office_admin_remove:
-            url = '%s?id=%s' % (url_for("officeadminremove.edit_view"), office_admin_remove.id)
+            url = url_for("officeadminremove.edit_view", id=office_admin_remove.id)
             return u"Entreprise retirée via Save : <a href='%s'>Voir la fiche de suppression</a>" % url
         else:
             return u'Aucune entreprise trouvée avec le siret %s' % form.siret.data
 
     # OfficeAdminAdd already exits ?
-    office_admin_add = OfficeAdminAdd.query.filter(OfficeAdminAdd.siret == form.siret.data).first()
+    office_admin_add = OfficeAdminAdd.query.filter_by(siret = form.siret.data).first()
     if office_admin_add:
-        url = '%s?id=%s' % (url_for("officeadminadd.edit_view"), office_admin_add.id)
+        url = url_for("officeadminadd.edit_view", id=office_admin_add.id)
         return u"Entreprise créée via Save : <a href='%s'>Voir la fiche d'ajout</a>" % url
 
     # OfficeAdminUpdate already exits ?
-    office_admin_update = OfficeAdminUpdate.query.filter(OfficeAdminUpdate.siret == form.siret.data).first()
+    office_admin_update = OfficeAdminUpdate.query.filter_by(siret = form.siret.data).first()
     if office_admin_update:
-        url = '%s?id=%s' % (url_for("officeadminupdate.edit_view"), office_admin_update.id)
+        url = url_for("officeadminupdate.edit_view", id=office_admin_update.id)
         return u"Entreprise modifiée via Save : <a href='%s'>Voir la fiche de modification</a>" % url
 
 

--- a/labonneboite/web/office/views.py
+++ b/labonneboite/web/office/views.py
@@ -7,6 +7,7 @@ import StringIO
 from slugify import slugify
 from sqlalchemy.orm.exc import NoResultFound
 from xhtml2pdf import pisa
+from urllib import urlencode
 
 from flask import abort, redirect, render_template, flash
 from flask import Blueprint, current_app
@@ -16,7 +17,7 @@ from flask import request, session, url_for
 from labonneboite.common import pdf as pdf_util
 from labonneboite.common import util
 from labonneboite.common.email_util import MandrillClient
-from labonneboite.common.models import Office
+from labonneboite.common.models import Office, OfficeAdminAdd, OfficeAdminUpdate, OfficeAdminRemove
 from labonneboite.conf import settings
 from labonneboite.common.contact_mode import CONTACT_MODE_STAGES
 
@@ -60,7 +61,11 @@ def change_info():
                 - Nom : %s, <br>
                 - E-mail : %s,<br>
                 - Tél. : %s,<br>
-                - Commentaire : %s<br><br>
+                - Commentaire : %s<br>
+                <hr>
+                - Status SAVE : %s
+                <hr>
+
                 Cordialement,<br>
                 La Bonne Boite""" % (
                     form.action.data,
@@ -70,7 +75,8 @@ def change_info():
                     form.email.data,
                     form.phone.data,
                     form.comment.data,
-               )
+                    make_save_suggestion(form)
+                )
             )
             msg = u"Merci pour votre message, nous reviendrons vers vous dès que possible."
             flash(msg, 'success')
@@ -113,6 +119,50 @@ def detail(siret):
         'kompass_url': "http://fr.kompass.com/searchCompanies?text=%s" % company.siret,
         'search_url': search_url,
     }
+
+def make_save_suggestion(form):
+    # Save informations
+    company = Office.query.filter(Office.siret == form.siret.data).first()
+    if not company:
+        # OfficeAdminRemove already exits ?
+        office_admin_remove = OfficeAdminRemove.query.filter(OfficeAdminRemove.siret == form.siret.data).first()
+        if office_admin_remove:
+            url = '%s?id=%s' % (url_for("officeadminremove.edit_view"), office_admin_remove.id)
+            return u"Entreprise retirée via Save : <a href='%s'>Voir la fiche de suppression</a>" % url
+        else:
+            return u'Aucune entreprise trouvée avec le siret %s' % form.siret.data
+
+    # OfficeAdminAdd already exits ?
+    office_admin_add = OfficeAdminAdd.query.filter(OfficeAdminAdd.siret == form.siret.data).first()
+    if office_admin_add:
+        url = '%s?id=%s' % (url_for("officeadminadd.edit_view"), office_admin_add.id)
+        return u"Entreprise créée via Save : <a href='%s'>Voir la fiche d'ajout</a>" % url
+
+    # OfficeAdminUpdate already exits ?
+    office_admin_update = OfficeAdminUpdate.query.filter(OfficeAdminUpdate.siret == form.siret.data).first()
+    if office_admin_update:
+        url = '%s?id=%s' % (url_for("officeadminupdate.edit_view"), office_admin_update.id)
+        return u"Entreprise modifiée via Save : <a href='%s'>Voir la fiche de modification</a>" % url
+
+
+    # No office AdminOffice found : suggest to create an OfficeAdminRemove and OfficeRemoveUpdate
+    params = {
+        'siret': form.siret.data,
+        'name': company.company_name,
+        'requested_by_email': form.email.data,
+        'requested_by_first_name': form.first_name.data,
+        'requested_by_last_name': form.last_name.data,
+        'requested_by_phone': form.phone.data,
+        'reason': form.comment.data,
+    }
+    if form.action.data == "enlever":
+        url = '%s?%s' % (url_for("officeadminremove.create_view"), urlencode(params))
+        status_save = u" Une suppression a été demandée : <a href='%s'>Créer une fiche de suppression</a>" % url
+    else:
+        url = '%s?%s' % (url_for("officeadminupdate.create_view"), urlencode(params))
+        status_save = u"Entreprise non modifiée via Save : <a href='%s'>Créer une fiche de modification</a>" % url
+
+    return status_save
 
 
 def fetch_resources(uri, rel):

--- a/labonneboite/web/templates/root/cookbook.html
+++ b/labonneboite/web/templates/root/cookbook.html
@@ -1569,9 +1569,9 @@
         <div class="form-error">
           <label for="action">Je souhaite :</label>
           <select id="action" name="action">
-            <option selected="" value="promouvoir">Que mon entreprise soit davantage mise en avant</option>
-            <option value="enlever">Supprimer mon entreprise des résultats</option>
-            <option value="modifier">Mettre à jour les informations de mon entreprise</option>
+            <option selected="selected" value="promouvoir">Promouvoir mon entreprise sur le site</option>
+            <option value="enlever">Retirer mon entreprise du site</option>
+            <option value="modifier">Modifier les coordonnées de mon entreprise sur le site</option>
             <option value="autre">Autre</option>
           </select>
         </div>


### PR DESCRIPTION
Ajoute une ligne supplémentaire dans le mail reçu en cas de contact pour faciliter la création/modification de fiches SAVE :

- 1er cas : le siret n'existe pas => indiqué dans le mail
- 2ème cas : siret existe et une fiche d'ajout existe => lien vers cette fiche (modifié)
- 3ème cas : siret existe et une fiche de modification existe => lien vers cette fiche
- 4ème cas : siret existe et une fiche de suppression existe => lien vers cette fiche
- 5ème cas : pas de modification Save trouvé et la personne a choisi l'option "retirer l'entreprise" => lien vers une nouvelle fiche de suppression pré-remplie avec les valeurs du mail (siret/tel/email/raison etc.)
- 6ème cas : pas de modification Save trouvé => lien vers une nouvelle fiche de modification pré-remplie avec les valeurs du mail (siret/tel/email/raison etc.)


NOTE : Agathe a aussi demandé des modifications dans ce formulaire