### PR TITLE
Make longitude and latitude required

### DIFF
--- a/labonneboite/web/admin/views/office_admin_add.py
+++ b/labonneboite/web/admin/views/office_admin_add.py
@@ -174,6 +174,14 @@ class OfficeAdminAddModelView(AdminModelViewMixin, ModelView):
         'reason': {
             'filters': [strip_filter],
         },
+        'x': {
+            'filters': [strip_filter, nospace_filter],
+            'validators': [validators.required()],
+        },
+        'y': {
+            'filters': [strip_filter, nospace_filter],
+            'validators': [validators.required()],
+        },
     }
 
     def validate_form(self, form):


### PR DESCRIPTION
Quand on créait une entreprise via SAVE et que l'on indique pas la localisation (longitude et latitude), on a des SQLOperatorError car 'x' et 'y' doivent être _not null_