### PR TITLE
Remove flag_alternance to a company

### DIFF
--- a/labonneboite/alembic/versions/38fad89a549c_create_remove_flag_alternance_in_office_.py
+++ b/labonneboite/alembic/versions/38fad89a549c_create_remove_flag_alternance_in_office_.py
@@ -1,0 +1,26 @@
+"""
+Create 'remove_flag_alternance' in office_admin_update
+
+Revision ID: 38fad89a549c
+Revises: 11fc7f39f7fc
+Create Date: 2017-12-13 09:58:01.163137
+"""
+from alembic import op
+from sqlalchemy.dialects import mysql
+import sqlalchemy as sa
+
+
+# Revision identifiers, used by Alembic.
+revision = '38fad89a549c'
+down_revision = '11fc7f39f7fc'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column(
+        'etablissements_admin_update',
+        sa.Column('remove_flag_alternance', mysql.TINYINT(display_width=1), autoincrement=False, nullable=False)
+    )
+
+def downgrade():
+    op.drop_column('etablissements_admin_update', 'remove_flag_alternance')

--- a/labonneboite/common/models/office_admin.py
+++ b/labonneboite/common/models/office_admin.py
@@ -137,6 +137,7 @@ class OfficeAdminUpdate(CRUDMixin, Base):
     remove_email = Column(Boolean, default=False, nullable=False)
     remove_phone = Column(Boolean, default=False, nullable=False)
     remove_website = Column(Boolean, default=False, nullable=False)
+    remove_flag_alternance = Column(Boolean, default=False, nullable=False)
 
     # Update requested by.
     requested_by_email = Column(String(191), default='', nullable=False)

--- a/labonneboite/scripts/create_index.py
+++ b/labonneboite/scripts/create_index.py
@@ -608,16 +608,19 @@ def update_offices():
         office = Office.query.filter_by(siret=office_to_update.siret).first()
 
         if office:
-
             # Apply changes in DB.
             office.email = u'' if office_to_update.remove_email else (office_to_update.new_email or office.email)
-            office.email_alternance = office_to_update.email_alternance or u''
+            office.email_alternance = u'' if office_to_update.remove_flag_alternance else (office_to_update.email_alternance or u'')
             office.tel = u'' if office_to_update.remove_phone else (office_to_update.new_phone or office.tel)
             office.website = u'' if office_to_update.remove_website else (office_to_update.new_website or office.website)
+            office.flag_alternance = False if office_to_update.remove_flag_alternance else office.flag_alternance
             office.save()
 
             # Apply changes in ElasticSearch.
-            body = {'doc': {'email': office.email, 'phone': office.tel, 'website': office.website }}
+            body = {'doc':
+                {'email': office.email, 'phone': office.tel, 'website': office.website,
+                'flag_alternance': 1 if office.flag_alternance else 0 }
+            }
 
             scores_by_rome = get_scores_by_rome(office, office_to_update)
             if scores_by_rome:

--- a/labonneboite/tests/scripts/test_create_index.py
+++ b/labonneboite/tests/scripts/test_create_index.py
@@ -528,11 +528,43 @@ class UpdateOfficesTest(CreateIndexBaseTest):
             email_alternance=u"email_alternance@mail.com",
         )
         office_to_update.save(commit=True)
-
         script.update_offices()
 
         office = Office.get(self.office.siret)
         self.assertEquals(office.email_alternance, "email_alternance@mail.com")
+
+    def test_update_office_remove_alternance(self):
+        """
+        Test `update_offices` to remove the flag_alternance and email_alternance
+        """
+        self.office.flag_alternance = 1
+        self.office.save()
+
+        # Add flag_alternance and email_alternance
+        office_to_update = OfficeAdminUpdate(
+            siret=self.office.siret,
+            name=self.office.company_name,
+            email_alternance=u"email_alternance@mail.com",
+        )
+        office_to_update.save(commit=True)
+        script.update_offices()
+
+
+        # Expected alternance infos
+        office = Office.get(self.office.siret)
+        self.assertEquals(office.flag_alternance, 1)
+        self.assertEquals(office.email_alternance, "email_alternance@mail.com")
+
+        # Remove alternance for this company
+        office_to_update.remove_flag_alternance = 1
+        office_to_update.save(commit=True)
+        script.update_offices()
+
+        # Expected no alternance infos
+        office = Office.get(self.office.siret)
+        self.assertEquals(office.flag_alternance, 0)
+        self.assertEquals(office.email_alternance, "")
+
 
     def test_update_office_add_naf(self):
         # Avoid removing romes if its score is too low

--- a/labonneboite/web/admin/views/office_admin_update.py
+++ b/labonneboite/web/admin/views/office_admin_update.py
@@ -44,6 +44,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         'remove_email',
         'remove_phone',
         'remove_website',
+        'remove_flag_alternance',
         'requested_by_email',
         'requested_by_first_name',
         'requested_by_last_name',
@@ -77,6 +78,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         'remove_email': u"Ne pas afficher l'email",
         'remove_phone': u"Ne pas afficher le téléphone",
         'remove_website': u"Ne pas afficher le site web",
+        'remove_flag_alternance': u'Ne pas afficher le libellé "Alternance"',
         'requested_by_email': u"Email",
         'requested_by_first_name': u"Prénom",
         'requested_by_last_name': u"Nom",
@@ -116,6 +118,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         'remove_email': u"Cocher cette case pour supprimer l'email",
         'remove_phone': u"Cocher cette case pour supprimer le téléphone",
         'remove_website': u"Cocher cette case pour supprimer le site web",
+        'remove_flag_alternance': u"Cocher cette case pour supprimer le libellé 'alternance' et l'email dédié à l'alternance",
         'reason': u"Raison de la modification.",
     }
 
@@ -133,6 +136,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         'remove_email',
         'remove_phone',
         'remove_website',
+        'remove_flag_alternance',
         'requested_by_email',
         'requested_by_first_name',
         'requested_by_last_name',


### PR DESCRIPTION
Possibilité de ne pas afficher le "alternance" et le mail dédié pour une entreprise (tout en la gardant dans les résultats classiques)