### PR TITLE
Acantin/add filters in api

### DIFF
--- a/labonneboite/common/search.py
+++ b/labonneboite/common/search.py
@@ -289,7 +289,9 @@ def build_json_body_elastic_search(
         flag_junior=0,
         flag_senior=0,
         flag_handicap=0,
-        aggregate_by=None):
+        aggregate_by=None,
+        departments=None,
+    ):
 
     score_for_rome_field_name = "scores_by_rome.%s" % rome_code
 
@@ -371,6 +373,15 @@ def build_json_body_elastic_search(
             }
         }
     })
+
+
+    if departments:
+        regex = '|'.join(departments)
+        filters.append({
+            'regexp': {
+                'department': regex
+            }
+        })
 
     # Build sort.
 

--- a/labonneboite/common/search.py
+++ b/labonneboite/common/search.py
@@ -376,10 +376,9 @@ def build_json_body_elastic_search(
 
 
     if departments:
-        regex = '|'.join(departments)
         filters.append({
-            'regexp': {
-                'department': regex
+            'terms': {
+                'department': departments
             }
         })
 

--- a/labonneboite/scripts/create_index.py
+++ b/labonneboite/scripts/create_index.py
@@ -372,7 +372,7 @@ def get_office_as_es_doc(office):
         'email': sanitized_email,
         'tel': office.tel,
         'website': sanitized_website,
-        'department': office.zipcode[0:2],
+        'department': office.departement,
         'flag_alternance': int(office.flag_alternance),
         'flag_junior': int(office.flag_junior),
         'flag_senior': int(office.flag_senior),

--- a/labonneboite/scripts/create_index.py
+++ b/labonneboite/scripts/create_index.py
@@ -243,6 +243,10 @@ mapping_office = {
             "type": "integer",
             "index": "not_analyzed",
         },
+        "department": {
+            "type": "string",
+            "index": "not_analyzed"
+        },
         "locations": {
             "type": "geo_point",
         },
@@ -368,6 +372,7 @@ def get_office_as_es_doc(office):
         'email': sanitized_email,
         'tel': office.tel,
         'website': sanitized_website,
+        'department': office.zipcode[0:2],
         'flag_alternance': int(office.flag_alternance),
         'flag_junior': int(office.flag_junior),
         'flag_senior': int(office.flag_senior),

--- a/labonneboite/tests/web/api/test_api.py
+++ b/labonneboite/tests/web/api/test_api.py
@@ -706,6 +706,17 @@ class ApiCompanyListTest(ApiBaseTest):
 
     def test_department_filters(self):
         with self.test_request_context:
+            # Invalid departments filter => Expected error message
+            params = self.add_security_params({
+                'commune_id': self.positions['paris']['commune_id'],
+                'rome_codes': u'N1202',
+                'user': u'labonneboite',
+                'departments': u'75,XX,YY'
+            })
+            rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
+            self.assertEqual(rv.status_code, 400)
+            self.assertIn(u'invalid departments : XX, YY', rv.data)
+
             # no departments filter => Expected 2 results
             params = self.add_security_params({
                 'commune_id': self.positions['paris']['commune_id'],

--- a/labonneboite/tests/web/api/test_api.py
+++ b/labonneboite/tests/web/api/test_api.py
@@ -704,6 +704,60 @@ class ApiCompanyListTest(ApiBaseTest):
             self.assertEqual(data['companies'][1]['siret'], u'00000000000016')
             self.assertEqual(data['companies'][1]['alternance'], True)
 
+    def test_department_filters(self):
+        with self.test_request_context:
+            # no departments filter => Expected 2 results
+            params = self.add_security_params({
+                'commune_id': self.positions['paris']['commune_id'],
+                'rome_codes': u'N1202',
+                'user': u'labonneboite'
+            })
+            rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
+            self.assertEqual(rv.status_code, 200)
+            data = json.loads(rv.data)
+            self.assertEqual(data['companies_count'], 2)
+            self.assertEqual(data['companies'][0]['siret'], u'00000000000017')
+            self.assertEqual(data['companies'][1]['siret'], u'00000000000018')
+
+            # Check two departments => Expected 2 results
+            params = self.add_security_params({
+                'commune_id': self.positions['paris']['commune_id'],
+                'rome_codes': u'N1202',
+                'user': u'labonneboite',
+                'departments': u'75,92'
+            })
+            rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
+            self.assertEqual(rv.status_code, 200)
+            data = json.loads(rv.data)
+            self.assertEqual(data['companies_count'], 2)
+            self.assertEqual(data['companies'][0]['siret'], u'00000000000017')
+            self.assertEqual(data['companies'][1]['siret'], u'00000000000018')
+
+            # Check department 75 => Expected 1 result
+            params = self.add_security_params({
+                'commune_id': self.positions['paris']['commune_id'],
+                'rome_codes': u'N1202',
+                'user': u'labonneboite',
+                'departments': u'75'
+            })
+            rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
+            self.assertEqual(rv.status_code, 200)
+            data = json.loads(rv.data)
+            self.assertEqual(data['companies_count'], 1)
+            self.assertEqual(data['companies'][0]['siret'], u'00000000000017')
+
+            # Check department 92 => Expected 1 result
+            params = self.add_security_params({
+                'commune_id': self.positions['paris']['commune_id'],
+                'rome_codes': u'N1202',
+                'user': u'labonneboite',
+                'departments': u'92'
+            })
+            rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
+            self.assertEqual(rv.status_code, 200)
+            data = json.loads(rv.data)
+            self.assertEqual(data['companies_count'], 1)
+            self.assertEqual(data['companies'][0]['siret'], u'00000000000018')
 
 class ApiCompanyListTrackingCodesTest(ApiBaseTest):
 

--- a/labonneboite/tests/web/api/test_api_base.py
+++ b/labonneboite/tests/web/api/test_api_base.py
@@ -85,7 +85,23 @@ class ApiBaseTest(DatabaseTest):
             }],
             'zip_code': u'86000',
             'commune_id': u'86194',
-        }
+        },
+        'paris': {
+            'coords': [{
+                'lat': 48.87950,
+                'lon': 2.283439,
+            }],
+            'zip_code': u'75004',
+            'commune_id': u'75056',
+        },
+        'neuilly-sur-seine': {
+            'coords': [{
+                'lat': 48.884831,
+                'lon': 2.26851,
+            }],
+            'zip_code': u'92200',
+            'commune_id': u'92051',
+        },
     }
 
     def setUp(self, *args, **kwargs):
@@ -306,6 +322,27 @@ class ApiBaseTest(DatabaseTest):
                 'name': u'Office 16',
                 'flag_alternance': 1,
                 'department': self.positions['poitiers']['zip_code'][0:2],
+            },
+            # For filter_by_department
+            {
+                'naf': u'5229A',  # Map to Rome N1202
+                'siret': u'00000000000017',
+                'score': 90,
+                'headcount': 53,
+                'locations': self.positions['paris']['coords'],
+                'name': u'Office 17',
+                'flag_alternance': 0,
+                'department': self.positions['paris']['zip_code'][0:2],
+            },
+            {
+                'naf': u'5229A',  # Map to Rome N1202
+                'siret': u'00000000000018',
+                'score': 78,
+                'headcount': 53,
+                'locations': self.positions['neuilly-sur-seine']['coords'],
+                'name': u'Office 18',
+                'flag_alternance': 0,
+                'department': self.positions['neuilly-sur-seine']['zip_code'][0:2],
             }
         ]
         for i, doc in enumerate(docs, start=1):

--- a/labonneboite/tests/web/api/test_api_base.py
+++ b/labonneboite/tests/web/api/test_api_base.py
@@ -125,6 +125,10 @@ class ApiBaseTest(DatabaseTest):
                             "type": "integer",
                             "index": "not_analyzed"
                         },
+                        "department": {
+                            "type": "string",
+                            "index": "not_analyzed"
+                        },
                         "locations": {
                             "type": "geo_point",
                         }
@@ -144,7 +148,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 11,
                 'locations': self.positions['bayonville_sur_mad']['coords'],
                 'name': u'Office 1',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['bayonville_sur_mad']['zip_code'][0:2],
             },
             {
                 'naf': u'7320Z',  # Map to ROME D1405.
@@ -153,7 +158,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 31,
                 'locations': self.positions['bayonville_sur_mad']['coords'],
                 'name': u'Office 2',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['bayonville_sur_mad']['zip_code'][0:2],
             },
             {
                 'naf': u'7320Z',  # Map to ROME D1405.
@@ -162,7 +168,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 31,
                 'locations': self.positions['bayonville_sur_mad']['coords'],
                 'name': u'Office 3',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['bayonville_sur_mad']['zip_code'][0:2],
             },
             {
                 'naf': u'7320Z',  # Map to ROME D1405.
@@ -171,7 +178,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 31,
                 'locations': self.positions['caen']['coords'],
                 'name': u'Office 4',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['caen']['zip_code'][0:2],
             },
             {
                 'naf': u'9511Z',  # Map to ROME M1801.
@@ -180,7 +188,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 31,
                 'locations': self.positions['caen']['coords'],
                 'name': u'Office 5',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['caen']['zip_code'][0:2],
             },
             # For NAF filter
             {
@@ -190,7 +199,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 31,
                 'locations': self.positions['metz']['coords'],
                 'name': u'Office 6',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['metz']['zip_code'][0:2],
             },
             {
                 'naf': u'5610C',  # Map to ROME D1508.
@@ -199,7 +209,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 50,
                 'locations': self.positions['metz']['coords'],
                 'name': u'Office 7',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['metz']['zip_code'][0:2],
             },
             # For result sort
             {
@@ -209,7 +220,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 50,
                 'locations': self.positions['nantes']['coords'],
                 'name': u'Office 8',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['nantes']['zip_code'][0:2],
             },
             {
                 'naf': u'7010Z', # Map to ROME D1211
@@ -218,7 +230,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 50,
                 'locations': self.positions['reze']['coords'], # City close to Nantes
                 'name': u'Office 9',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['reze']['zip_code'][0:2],
             },
             # For contract filter
             {
@@ -228,7 +241,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 34,
                 'locations': self.positions['lille']['coords'],
                 'name': u'Office 10',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['lille']['zip_code'][0:2],
             },
             {
                 'naf': u'4669A', # Map to Rome D1213
@@ -237,7 +251,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 65,
                 'locations': self.positions['lille']['coords'],
                 'name': u'Office 11',
-                'flag_alternance': 1
+                'flag_alternance': 1,
+                'department': self.positions['lille']['zip_code'][0:2],
             },
             # For headcount filter
             {
@@ -247,7 +262,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 11,
                 'locations': self.positions['toulouse']['coords'],
                 'name': u'Office 12',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['toulouse']['zip_code'][0:2],
             },
             {
                 'naf': u'7010Z',  # Map to Rome M1202
@@ -256,7 +272,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 22,
                 'locations': self.positions['toulouse']['coords'],
                 'name': u'Office 13',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['toulouse']['zip_code'][0:2],
             },
             # For headcount_text
             {
@@ -266,7 +283,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 53, # headcount_text : '10 000 salariés et plus'
                 'locations': self.positions['pau']['coords'],
                 'name': u'Office 14',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['pau']['zip_code'][0:2],
             },
             # For flag_alternance in response
             {
@@ -276,7 +294,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 53,
                 'locations': self.positions['poitiers']['coords'],
                 'name': u'Office 15',
-                'flag_alternance': 0
+                'flag_alternance': 0,
+                'department': self.positions['poitiers']['zip_code'][0:2],
             },
             {
                 'naf': u'4648Z',  # Map to Rome B1603
@@ -285,7 +304,8 @@ class ApiBaseTest(DatabaseTest):
                 'headcount': 53,
                 'locations': self.positions['poitiers']['coords'],
                 'name': u'Office 16',
-                'flag_alternance': 1
+                'flag_alternance': 1,
+                'department': self.positions['poitiers']['zip_code'][0:2],
             }
         ]
         for i, doc in enumerate(docs, start=1):

--- a/labonneboite/tests/web/api/test_api_base.py
+++ b/labonneboite/tests/web/api/test_api_base.py
@@ -8,6 +8,7 @@ from labonneboite.web.api import util
 from labonneboite.conf import settings
 from labonneboite.common import mapping as mapping_util
 from labonneboite.common import scoring as scoring_util
+from labonneboite.scripts.create_index import mapping_office
 
 
 class ApiBaseTest(DatabaseTest):
@@ -115,41 +116,7 @@ class ApiBaseTest(DatabaseTest):
         # Create new index.
         request_body = {
             "mappings": {
-                "office": {
-                    "properties": {
-                        "naf": {
-                            "type": "string",
-                            "index": "not_analyzed"
-                        },
-                        "siret": {
-                            "type": "string",
-                            "index": "not_analyzed"
-                        },
-                        "name": {
-                            "type": "string",
-                            "index": "not_analyzed"
-                        },
-                        "score": {
-                            "type": "integer",
-                            "index": "not_analyzed"
-                        },
-                        "flag_alternance": {
-                            "type": "integer",
-                            "index": "not_analyzed"
-                        },
-                        "headcount": {
-                            "type": "integer",
-                            "index": "not_analyzed"
-                        },
-                        "department": {
-                            "type": "string",
-                            "index": "not_analyzed"
-                        },
-                        "locations": {
-                            "type": "geo_point",
-                        }
-                    }
-                }
+                "office": mapping_office
             }
         }
 

--- a/labonneboite/web/api/views.py
+++ b/labonneboite/web/api/views.py
@@ -162,6 +162,13 @@ def company_list():
         if not headcount:
             return u'invalid headcount value. Possible values : %s' % ', '.join(HEADCOUNT_VALUES.keys()), 400
 
+    departments = []
+    if 'departments' in request.args and request.args.get('departments'):
+        departments = request.args.get('departments').split(',')
+        unknown_departments = [dep for dep in departments if not geocoding.is_departement(dep)]
+        if unknown_departments:
+            return u'invalid departments : %s' % ', '.join(unknown_departments), 400
+
     companies, companies_count, _ = search.fetch_companies(
         naf_codes_list,
         rome_code,
@@ -173,6 +180,7 @@ def company_list():
         to_number=to_number,
         flag_alternance=flag_alternance,
         sort=sort,
+        departments=departments,
     )
 
     # Define additional query string to add to office urls


### PR DESCRIPTION
Permet de filtrer les résultats par département.
- Ajout du champ department dans ES
- Filtre dans l'API
- Regex pour la requête ES

Pour le dernier point, n'hésite pas à me dire si tu vois des points d'amélioration, j'ai notamment des craintes niveau performance avec l'ajout d'une regex (même si c'est le cas qu'en présence du filtre) 