### PR TITLE
Acantin/save 9 multi siret office update

### DIFF
--- a/labonneboite/alembic/versions/e21ab8255e02_convert_officeadminupdate_siret_in_text.py
+++ b/labonneboite/alembic/versions/e21ab8255e02_convert_officeadminupdate_siret_in_text.py
@@ -18,18 +18,11 @@ depends_on = None
 
 
 def upgrade():
-    op.alter_column(
-        table_name='etablissements_admin_update',
-        column_name='siret',
-        type=mysql.TEXT(collation=u'utf8mb4_unicode_ci', length=65000),
-        null=False
-    )
+    conn = op.get_bind()
+    conn.execute("ALTER TABLE `etablissements_admin_update` CHANGE siret sirets TEXT;")
+
 
 
 def downgrade():
-    op.alter_column(
-        table_name='etablissements_admin_update',
-        column_name='siret',
-        type=mysql.VARCHAR(collation=u'utf8mb4_unicode_ci', length=191),
-        null=False
-    )
+    conn = op.get_bind()
+    conn.execute("ALTER TABLE `etablissements_admin_update` CHANGE sirets siret VARCHAR(191);")

--- a/labonneboite/alembic/versions/e21ab8255e02_convert_officeadminupdate_siret_in_text.py
+++ b/labonneboite/alembic/versions/e21ab8255e02_convert_officeadminupdate_siret_in_text.py
@@ -1,0 +1,35 @@
+"""
+convert OfficeAdminUpdate.siret in text
+
+Revision ID: e21ab8255e02
+Revises: 38fad89a549c
+Create Date: 2018-01-11 14:10:58.780076
+"""
+from alembic import op
+from sqlalchemy.dialects import mysql
+import sqlalchemy as sa
+
+
+# Revision identifiers, used by Alembic.
+revision = 'e21ab8255e02'
+down_revision = '38fad89a549c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        table_name='etablissements_admin_update',
+        column_name='siret',
+        type=mysql.TEXT(collation=u'utf8mb4_unicode_ci', length=65000),
+        null=False
+    )
+
+
+def downgrade():
+    op.alter_column(
+        table_name='etablissements_admin_update',
+        column_name='siret',
+        type=mysql.VARCHAR(collation=u'utf8mb4_unicode_ci', length=191),
+        null=False
+    )

--- a/labonneboite/common/models/office_admin.py
+++ b/labonneboite/common/models/office_admin.py
@@ -111,7 +111,7 @@ class OfficeAdminUpdate(CRUDMixin, Base):
     id = Column(Integer, primary_key=True)
 
     # Stores a list of SIRET as a string separated by `SEPARATORS`
-    siret = Column(Text, default='', nullable=False, unique=False)
+    sirets = Column(Text, default='', nullable=False, unique=False)
 
     name = Column(String(191), default='', nullable=False)
 

--- a/labonneboite/common/models/office_admin.py
+++ b/labonneboite/common/models/office_admin.py
@@ -109,7 +109,10 @@ class OfficeAdminUpdate(CRUDMixin, Base):
     SEPARATORS = [u'\n', u'\r']
 
     id = Column(Integer, primary_key=True)
-    siret = Column(String(191), nullable=False, unique=True)
+
+    # Stores a list of SIRET as a string separated by `SEPARATORS`
+    siret = Column(Text, default='', nullable=False, unique=False)
+
     name = Column(String(191), default='', nullable=False)
 
     # Info to update.

--- a/labonneboite/common/pdf.py
+++ b/labonneboite/common/pdf.py
@@ -32,6 +32,7 @@ def write_file(office, data):
 
 
 def delete_file(office):
+    # FIXME : Works only on one front-end...
     filename = get_file_path(office)
     if os.path.exists(filename):
         os.remove(filename)

--- a/labonneboite/common/pdf.py
+++ b/labonneboite/common/pdf.py
@@ -32,7 +32,6 @@ def write_file(office, data):
 
 
 def delete_file(office):
-    # FIXME : Works only on one front-end...
     filename = get_file_path(office)
     if os.path.exists(filename):
         os.remove(filename)

--- a/labonneboite/common/siret.py
+++ b/labonneboite/common/siret.py
@@ -1,9 +1,4 @@
 
 def is_siret(siret):
     # A valid SIRET is composed by 14 digits
-    try:
-        int(siret)
-    except ValueError:
-        return False
-
-    return len(siret) == 14
+    return len(siret) == 14 and siret.isdigit()

--- a/labonneboite/common/siret.py
+++ b/labonneboite/common/siret.py
@@ -1,0 +1,9 @@
+
+def is_siret(siret):
+    # A valid SIRET is composed by 14 digits
+    try:
+        int(siret)
+    except ValueError:
+        return False
+
+    return len(siret) == 14

--- a/labonneboite/scripts/create_index.py
+++ b/labonneboite/scripts/create_index.py
@@ -609,7 +609,7 @@ def update_offices():
     es = Elasticsearch(timeout=ES_TIMEOUT)
 
     for office_to_update in db_session.query(OfficeAdminUpdate).all():
-        for siret in OfficeAdminUpdate.as_list(office_to_update.siret):
+        for siret in OfficeAdminUpdate.as_list(office_to_update.sirets):
 
             office = Office.query.filter_by(siret=siret).first()
 

--- a/labonneboite/scripts/create_index.py
+++ b/labonneboite/scripts/create_index.py
@@ -609,46 +609,47 @@ def update_offices():
     es = Elasticsearch(timeout=ES_TIMEOUT)
 
     for office_to_update in db_session.query(OfficeAdminUpdate).all():
+        for siret in OfficeAdminUpdate.as_list(office_to_update.siret):
 
-        office = Office.query.filter_by(siret=office_to_update.siret).first()
+            office = Office.query.filter_by(siret=siret).first()
 
-        if office:
-            # Apply changes in DB.
-            office.email = u'' if office_to_update.remove_email else (office_to_update.new_email or office.email)
-            office.email_alternance = u'' if office_to_update.remove_flag_alternance else (office_to_update.email_alternance or u'')
-            office.tel = u'' if office_to_update.remove_phone else (office_to_update.new_phone or office.tel)
-            office.website = u'' if office_to_update.remove_website else (office_to_update.new_website or office.website)
-            office.flag_alternance = False if office_to_update.remove_flag_alternance else office.flag_alternance
-            office.save()
+            if office:
+                # Apply changes in DB.
+                office.email = u'' if office_to_update.remove_email else (office_to_update.new_email or office.email)
+                office.email_alternance = u'' if office_to_update.remove_flag_alternance else (office_to_update.email_alternance or u'')
+                office.tel = u'' if office_to_update.remove_phone else (office_to_update.new_phone or office.tel)
+                office.website = u'' if office_to_update.remove_website else (office_to_update.new_website or office.website)
+                office.flag_alternance = False if office_to_update.remove_flag_alternance else office.flag_alternance
+                office.save()
 
-            # Apply changes in ElasticSearch.
-            body = {'doc':
-                {'email': office.email, 'phone': office.tel, 'website': office.website,
-                'flag_alternance': 1 if office.flag_alternance else 0 }
-            }
+                # Apply changes in ElasticSearch.
+                body = {'doc':
+                    {'email': office.email, 'phone': office.tel, 'website': office.website,
+                    'flag_alternance': 1 if office.flag_alternance else 0 }
+                }
 
-            scores_by_rome = get_scores_by_rome(office, office_to_update)
-            if scores_by_rome:
-                body['doc']['scores_by_rome'] = scores_by_rome
+                scores_by_rome = get_scores_by_rome(office, office_to_update)
+                if scores_by_rome:
+                    body['doc']['scores_by_rome'] = scores_by_rome
 
-            # The update API makes partial updates: existing `scalar` fields are overwritten,
-            # but `objects` fields are merged together.
-            # https://www.elastic.co/guide/en/elasticsearch/guide/1.x/partial-updates.html
-            # However `scores_by_rome` needs to be overwritten because it may change over time.
-            # To do this, we perform 2 requests: the first one reset `scores_by_rome`, the
-            # second one populate it.
-            delete_body = {'doc': {'scores_by_rome': None}}
+                # The update API makes partial updates: existing `scalar` fields are overwritten,
+                # but `objects` fields are merged together.
+                # https://www.elastic.co/guide/en/elasticsearch/guide/1.x/partial-updates.html
+                # However `scores_by_rome` needs to be overwritten because it may change over time.
+                # To do this, we perform 2 requests: the first one reset `scores_by_rome`, the
+                # second one populate it.
+                delete_body = {'doc': {'scores_by_rome': None}}
 
-            # Unfortunately these cannot easily be bulked :-(
-            # The reason is there is no way to tell bulk to ignore missing documents (404)
-            # for a partial update. Tried it and failed it on Oct 2017 @vermeer.
-            es.update(index=INDEX_NAME, doc_type=OFFICE_TYPE, id=office_to_update.siret, body=delete_body,
-                      params={'ignore': 404})
-            es.update(index=INDEX_NAME, doc_type=OFFICE_TYPE, id=office_to_update.siret, body=body,
-                      params={'ignore': 404})
+                # Unfortunately these cannot easily be bulked :-(
+                # The reason is there is no way to tell bulk to ignore missing documents (404)
+                # for a partial update. Tried it and failed it on Oct 2017 @vermeer.
+                es.update(index=INDEX_NAME, doc_type=OFFICE_TYPE, id=siret, body=delete_body,
+                        params={'ignore': 404})
+                es.update(index=INDEX_NAME, doc_type=OFFICE_TYPE, id=siret, body=body,
+                        params={'ignore': 404})
 
-            # Delete the current PDF, it will be regenerated at next download attempt.
-            pdf_util.delete_file(office)
+                # Delete the current PDF, it will be regenerated at next download attempt.
+                pdf_util.delete_file(office)
 
 @timeit
 def update_offices_geolocations():

--- a/labonneboite/web/admin/forms.py
+++ b/labonneboite/web/admin/forms.py
@@ -1,14 +1,14 @@
 # coding: utf8
 
 from wtforms import ValidationError
-
+from labonneboite.common.siret import is_siret
 
 def siret_validator(form, field):
     """
     Validate siret number.
     http://wtforms.readthedocs.io/en/latest/validators.html#custom-validators
     """
-    if not field.data.isdigit() or len(field.data) != 14:
+    if not is_siret(field.data):
         raise ValidationError(u"Le numéro SIRET doit être composé de 14 chiffres")
 
 

--- a/labonneboite/web/admin/views/office_admin_update.py
+++ b/labonneboite/web/admin/views/office_admin_update.py
@@ -6,18 +6,10 @@ from wtforms import validators
 
 from labonneboite.common import mapping as mapping_util
 from labonneboite.common.models import Office, OfficeAdminUpdate
+from labonneboite.common.siret import is_siret
 from labonneboite.web.admin.forms import nospace_filter, phone_validator, strip_filter, siret_validator
 from labonneboite.web.admin.utils import datetime_format, AdminModelViewMixin
 from labonneboite.conf import settings
-
-def is_siret(siret):
-    # A valid SIRET is composed by 14 digits
-    try:
-        int(siret)
-    except ValueError:
-        return False
-
-    return len(siret) == 14
 
 class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
     """
@@ -256,7 +248,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         if is_valid:
             for siret in sirets:
                 if 'id' in request.args:
-                    # Avoid conflict with himself if update by adding id != request.args['id']
+                    # Avoid conflict with itself if update by adding id != request.args['id']
                     office_update_conflict = OfficeAdminUpdate.query.filter(
                         OfficeAdminUpdate.siret.like("%{}%".format(siret)),
                         OfficeAdminUpdate.id != request.args['id']

--- a/labonneboite/web/admin/views/office_admin_update.py
+++ b/labonneboite/web/admin/views/office_admin_update.py
@@ -231,6 +231,11 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         sirets = OfficeAdminUpdate.as_list(form.data['siret'])
         only_one_siret = len(sirets) == 1
 
+        if is_valid and not sirets:
+            message = u"Le champs 'Sirets' est obligatoire. Veuillez le renseigner."
+            flash(message, 'error')
+            return False
+
         if is_valid:
             for siret in sirets:
                 if not is_siret(siret):

--- a/labonneboite/web/admin/views/office_admin_update.py
+++ b/labonneboite/web/admin/views/office_admin_update.py
@@ -19,19 +19,19 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
 
     can_delete = False
     can_view_details = True
-    column_searchable_list = ['siret', 'name']
+    column_searchable_list = ['sirets', 'name']
     column_default_sort = ('date_created', True)
     page_size = 100
 
     column_list = [
-        'siret',
+        'sirets',
         'name',
         'reason',
         'date_created',
     ]
 
     column_details_list = [
-        'siret',
+        'sirets',
         'name',
         'boost',
         'romes_to_boost',
@@ -64,7 +64,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
     }
 
     column_labels = {
-        'siret': u"Sirets",
+        'sirets': u"Sirets",
         'name': u"Nom de l'entreprise",
         'reason': u"Raison",
         'boost': u"Booster le score",
@@ -90,7 +90,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
     }
 
     column_descriptions = {
-        'siret': Markup(
+        'sirets': Markup(
             u"Veuillez entrer un siret par ligne"
             u"<br>"
             u"Tous les sirets doivent être associés au même NAF (le premier NAF servant de référence)"
@@ -128,7 +128,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
     }
 
     form_columns = [
-        'siret',
+        'sirets',
         'name',
         'boost',
         'romes_to_boost',
@@ -150,7 +150,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
     ]
 
     form_args = {
-        'siret': {
+        'sirets': {
             'filters': [strip_filter, nospace_filter],
         },
         'name': {
@@ -200,7 +200,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
     def create_form(self):
         form = super(OfficeAdminUpdateModelView, self).create_form()
         if 'siret' in request.args:
-            form.siret.data = request.args['siret']
+            form.sirets.data = request.args['siret']
         if 'name' in request.args:
             form.name.data = request.args['name']
         if 'requested_by_email' in request.args:
@@ -220,7 +220,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         is_valid = super(OfficeAdminUpdateModelView, self).validate_form(form)
 
         # All sirets must be well formed
-        sirets = OfficeAdminUpdate.as_list(form.data['siret'])
+        sirets = OfficeAdminUpdate.as_list(form.data['sirets'])
         only_one_siret = len(sirets) == 1
 
         if is_valid and not sirets:
@@ -250,12 +250,12 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
                 if 'id' in request.args:
                     # Avoid conflict with itself if update by adding id != request.args['id']
                     office_update_conflict = OfficeAdminUpdate.query.filter(
-                        OfficeAdminUpdate.siret.like("%{}%".format(siret)),
+                        OfficeAdminUpdate.sirets.like("%{}%".format(siret)),
                         OfficeAdminUpdate.id != request.args['id']
                     )
                 else:
                     office_update_conflict = OfficeAdminUpdate.query.filter(
-                        OfficeAdminUpdate.siret.like("%{}%".format(siret))
+                        OfficeAdminUpdate.sirets.like("%{}%".format(siret))
                     )
 
                 if office_update_conflict.count() > 0:

--- a/labonneboite/web/office/views.py
+++ b/labonneboite/web/office/views.py
@@ -149,7 +149,7 @@ def make_save_suggestion(form):
         return u"Entreprise créée via Save : <a href='%s'>Voir la fiche d'ajout</a>" % dirty_fix_url(url)
 
     # OfficeAdminUpdate already exits ?
-    office_admin_update = OfficeAdminUpdate.query.filter(OfficeAdminUpdate.siret.like("%{}%".format(form.siret.data))).first()
+    office_admin_update = OfficeAdminUpdate.query.filter(OfficeAdminUpdate.sirets.like("%{}%".format(form.siret.data))).first()
 
     if office_admin_update:
         url = url_for("officeadminupdate.edit_view", id=office_admin_update.id)

--- a/labonneboite/web/office/views.py
+++ b/labonneboite/web/office/views.py
@@ -149,7 +149,8 @@ def make_save_suggestion(form):
         return u"Entreprise créée via Save : <a href='%s'>Voir la fiche d'ajout</a>" % dirty_fix_url(url)
 
     # OfficeAdminUpdate already exits ?
-    office_admin_update = OfficeAdminUpdate.query.filter_by(siret=form.siret.data).first()
+    office_admin_update = OfficeAdminUpdate.query.filter(OfficeAdminUpdate.siret.like("%{}%".format(form.siret.data))).first()
+
     if office_admin_update:
         url = url_for("officeadminupdate.edit_view", id=office_admin_update.id)
         return u"Entreprise modifiée via Save : <a href='%s'>Voir la fiche de modification</a>" % dirty_fix_url(url)


### PR DESCRIPTION
But de la modification

Les modifications d'entreprises ne peuvent être faites que par un siret à la fois ce qui est contaignant quand une modification modifie 3, 10 voire 100 entreprises ! Cette PR a pour but de pouvoir indiquer plusieurs sirets dans un OfficeAdminUpdate

**Règles :** 
Si plusieurs sirets sont renseignés :
- On ne vérifie plus si les entreprises sont du même NAF
- On ne vérifie si les romes boostés sont associés aux entreprises
- Si les sirets existent en base de données (souhait d'Agathe)

**Tests :** beaucoup de tests qui consistent à vérifier que ceux qui fonctionnaient en simple siret marche aussi en multi-siret. 
