### PR TITLE
Improve logging level of PEAM errors

### DIFF
--- a/labonneboite/web/app.py
+++ b/labonneboite/web/app.py
@@ -335,13 +335,13 @@ def social_auth_error(error):
     Handle the situation where a user clicks the `cancel` button on a third party auth provider website.
     """
     flash(u"Une erreur est survenue lors de votre connexion. Veuillez réessayer", 'error')
+    # Don't log errors that are not our responsibility
     if not isinstance(error, (
             social_exceptions.AuthCanceled,
             social_exceptions.AuthUnreachableProvider,
             social_exceptions.AuthStateForbidden,
     )):
-        # Don't log errors that are not our responsibility
-        app.logger.warn("PEAM error: %s", error)
+        app.logger.exception(error)
 
     # If there us a next url in session and it's safe, redirect to it.
     next_url = session.get('next')


### PR DESCRIPTION
Despite reducing the number of PEAM errors logged, we still see warnings
in opbeat: https://opbeat.com/labonneboite/lbb-prod/errors/1877/

To better understand where these exceptions come from, we increase the
level of logging to include the full stacktrace.