### PR TITLE
No empty latitude or longitude arguments in api

### DIFF
--- a/labonneboite/tests/web/api/test_api.py
+++ b/labonneboite/tests/web/api/test_api.py
@@ -353,6 +353,9 @@ class ApiCompanyListTest(ApiBaseTest):
                 'rome_codes': rome,
             })
             rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
+            data = json.loads(rv.data)
+            self.assertEqual(data['rome_code'], rome)
+            self.assertEqual(data['rome_label'], u'Animation de vente')
 
     def test_ok_if_distance_value_is_zero(self):
         """
@@ -367,9 +370,6 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data)
-            self.assertEqual(data['rome_code'], rome)
-            self.assertEqual(data['rome_label'], u'Animation de vente')
 
     def test_error_when_latitude_or_longitude_are_empty(self):
         """

--- a/labonneboite/tests/web/api/test_api.py
+++ b/labonneboite/tests/web/api/test_api.py
@@ -371,7 +371,7 @@ class ApiCompanyListTest(ApiBaseTest):
             self.assertEqual(data['rome_code'], rome)
             self.assertEqual(data['rome_label'], u'Animation de vente')
 
-    def test_wrong_latitude_or_longitude_values(self):
+    def test_error_when_latitude_or_longitude_are_empty(self):
         """
         If latitude or longitude are empty, throw a Bad Request Error
         """
@@ -379,6 +379,21 @@ class ApiCompanyListTest(ApiBaseTest):
             params = self.add_security_params({
                 'latitude': '',
                 'longitude': '',
+                'rome_codes': u'D1405',
+                'distance': u'10',
+                'user': u'labonneboite',
+            })
+            rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
+            self.assertEqual(rv.status_code, 400)
+
+    def test_error_when_latitude_or_longitude_are_strings(self):
+        """
+        If latitude or longitude are empty, throw a Bad Request Error
+        """
+        with self.test_request_context:
+            params = self.add_security_params({
+                'latitude': 'xxx',
+                'longitude': 'xxx',
                 'rome_codes': u'D1405',
                 'distance': u'10',
                 'user': u'labonneboite',

--- a/labonneboite/tests/web/api/test_api.py
+++ b/labonneboite/tests/web/api/test_api.py
@@ -263,7 +263,7 @@ class ApiCompanyListTest(ApiBaseTest):
 
     def test_string_distance_value(self):
         """
-        A non-integer value for `distance` should trigger a 400 error.
+        A wrong value for `distance` should trigger an error.
         """
         with self.test_request_context:
             params = self.add_security_params({
@@ -353,12 +353,40 @@ class ApiCompanyListTest(ApiBaseTest):
                 'rome_codes': rome,
             })
             rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
+
+    def test_ok_if_distance_value_is_zero(self):
+        """
+        A wrong value for `distance` should trigger an error.
+        """
+        with self.test_request_context:
+            params = self.add_security_params({
+                'commune_id': self.positions['caen']['commune_id'],
+                'rome_codes': u'D1405',
+                'distance': u'0',
+                'user': u'labonneboite',
+            })
+            rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
             self.assertEqual(rv.status_code, 200)
             data = json.loads(rv.data)
             self.assertEqual(data['rome_code'], rome)
             self.assertEqual(data['rome_label'], u'Animation de vente')
 
-    def test_rome_not_mapped_to_any_naf_should_not_trigger_any_error(self):
+    def test_wrong_latitude_or_longitude_values(self):
+        """
+        If latitude or longitude are empty, throw a Bad Request Error
+        """
+        with self.test_request_context:
+            params = self.add_security_params({
+                'latitude': '',
+                'longitude': '',
+                'rome_codes': u'D1405',
+                'distance': u'10',
+                'user': u'labonneboite',
+            })
+            rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
+            self.assertEqual(rv.status_code, 400)
+
+    def test_rome_without_any_naf_should_not_trigger_any_error(self):
         with self.test_request_context:
             rome_with_naf_mapping = u'K1706'
             rome_without_naf_mapping = u'L1510'

--- a/labonneboite/tests/web/api/test_api.py
+++ b/labonneboite/tests/web/api/test_api.py
@@ -386,6 +386,21 @@ class ApiCompanyListTest(ApiBaseTest):
             rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
             self.assertEqual(rv.status_code, 400)
 
+    def test_ok_when_latitude_or_longitude_equal_zero(self):
+        """
+        If latitude and longitude equal, throw No Error
+        """
+        with self.test_request_context:
+            params = self.add_security_params({
+                'latitude': '0',
+                'longitude': '0',
+                'rome_codes': u'D1405',
+                'distance': u'10',
+                'user': u'labonneboite',
+            })
+            rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))
+            self.assertEqual(rv.status_code, 200)
+
     def test_error_when_latitude_or_longitude_are_strings(self):
         """
         If latitude or longitude are empty, throw a Bad Request Error

--- a/labonneboite/web/api/views.py
+++ b/labonneboite/web/api/views.py
@@ -200,6 +200,13 @@ def get_location(request_args):
     elif 'latitude' in request_args and 'longitude' in request_args:
         if not request_args.get('latitude') or not request_args.get('longitude'):
             raise InvalidFetcherArgument(u'latitude or longitude (or both) have no value')
+
+        try:
+            float(request_args.get('latitude'))
+            float(request_args.get('longitude'))
+        except ValueError:
+            raise InvalidFetcherArgument(u'latitude or longitude (or both) are no float values')
+
         location = search.Location(request_args.get('latitude'), request_args.get('longitude'))
 
     else:

--- a/labonneboite/web/api/views.py
+++ b/labonneboite/web/api/views.py
@@ -198,7 +198,10 @@ def get_location(request_args):
         location = search.Location(city['coords']['lat'], city['coords']['lon'], request_args.get('commune_id'))
         zipcode = city['zipcode']
     elif 'latitude' in request_args and 'longitude' in request_args:
+        if not request_args.get('latitude') or not request_args.get('longitude'):
+            raise InvalidFetcherArgument(u'latitude or longitude (or both) have no value')
         location = search.Location(request_args.get('latitude'), request_args.get('longitude'))
+
     else:
         raise InvalidFetcherArgument(u'missing arguments: either commune_id or latitude and longitude')
 

--- a/labonneboite/web/api/views.py
+++ b/labonneboite/web/api/views.py
@@ -202,12 +202,12 @@ def get_location(request_args):
             raise InvalidFetcherArgument(u'latitude or longitude (or both) have no value')
 
         try:
-            float(request_args.get('latitude'))
-            float(request_args.get('longitude'))
+            latitude = float(request_args['latitude'])
+            longitude = float(request_args['longitude'])
         except ValueError:
-            raise InvalidFetcherArgument(u'latitude or longitude (or both) are no float values')
+            raise InvalidFetcherArgument(u'latitude or longitude (or both) must be float')
 
-        location = search.Location(request_args.get('latitude'), request_args.get('longitude'))
+        location = search.Location(latitude, longitude)
 
     else:
         raise InvalidFetcherArgument(u'missing arguments: either commune_id or latitude and longitude')


### PR DESCRIPTION
review @vgrange @regisb :)

Ajouts de tests pour retourner des erreurs 400 si la latitude ou la longitude est vide ou n'est pas un nombre flottant.

Note : Côté LBB, cela générait pas une erreur 500 suite car Elastic Search n'arrivait pas à générer la requête. On peut donc considérer qu'aucun service considérait ce cas comme une feature...

Je n'ai pas non plus trouvé dans les logs de nginx de ce type, excepté les erreurs du mercredi 14 vers 11h50 (ainsi que mes essais de réplication). Je vous laisse toutefois le soin de vérifier.
