### PR TITLE
Don't log state-related PEAM errors due to clients

### DIFF
--- a/labonneboite/web/app.py
+++ b/labonneboite/web/app.py
@@ -340,6 +340,8 @@ def social_auth_error(error):
             social_exceptions.AuthCanceled,
             social_exceptions.AuthUnreachableProvider,
             social_exceptions.AuthStateForbidden,
+            social_exceptions.AuthStateMissing,
+            social_exceptions.AuthMissingParameter,
     )):
         app.logger.exception(error)
 


### PR DESCRIPTION
AuthStateMissing are due to a missing session state parameter.

AuthMissingParameter is triggered when the request does not contain a
valid state or redirect_state parameter.

Both these errors are caused by client or 3rd-party behaviour, so we
should not log them.

This should solve https://opbeat.com/labonneboite/lbb-prod/errors/2906/