### PR TITLE
Add chain name in API response

### DIFF
--- a/labonneboite/web/api/views.py
+++ b/labonneboite/web/api/views.py
@@ -324,6 +324,7 @@ def office_details(siret):
         'naf': office.naf,
         'naf_text': office.naf_text,
         'name': office.name,
+        'raison_sociale': office.company_name,
         'siret': office.siret,
         'stars': office.stars,
         'url': office.url,


### PR DESCRIPTION
Dans le cadre de LBA, j'ai besoin de récupérer l'enseigne pour l'afficher sur le détails d'une entreprise (`office_name` côté LBB... même le nom me semble mal choisi).