### PR TITLE
vgrange/api_pefr

### DIFF
--- a/labonneboite/tests/web/api/test_api.py
+++ b/labonneboite/tests/web/api/test_api.py
@@ -267,9 +267,13 @@ class ApiCompanyListTest(ApiBaseTest):
 
     def test_rome_without_any_naf_should_not_trigger_any_error(self):
         with self.test_request_context:
+            rome_with_naf_mapping = u'K1706'
+            rome_without_naf_mapping = u'L1510'
+            self.assertIn(rome_with_naf_mapping, mapping_util.MANUAL_ROME_NAF_MAPPING)
+            self.assertNotIn(rome_without_naf_mapping, mapping_util.MANUAL_ROME_NAF_MAPPING)
             params = self.add_security_params({
                 'commune_id': self.positions['caen']['commune_id'],
-                'rome_codes': u'K1701',
+                'rome_codes': rome_without_naf_mapping,
                 'user': u'labonneboite',
             })
             rv = self.app.get('%s?%s' % (url_for("api.company_list"), urlencode(params)))

--- a/labonneboite/web/api/util.py
+++ b/labonneboite/web/api/util.py
@@ -74,7 +74,8 @@ def compute_signature(args, api_key):
 def check_signature(request, requested_signature, api_key):
     args = {}
     for k, v in request.args.iteritems():
-        args[k] = v
+        # unicode parameters (e.g. rome_codes_keyword_search) need to be properly encoded
+        args[k] = v.encode('utf8')
     computed_signature = compute_signature(args, api_key)
     if not computed_signature == requested_signature:
         raise InvalidSignatureException


### PR DESCRIPTION
review svp @AlexandreCantin  pour mémoire @regisb 

au menu:

- recherche de rome par texte libre (opti perf: 1 résultat au lieu de 10, et caching) + gérer le cas où aucun rome ne matche
- on renvoit l'URL de la home si zéro résultats (demande de PE.fr)
- nouveau endpoint company/count (opti perf pour PE.fr)

note to self: bien prévenir PE.fr de la 400 en cas de non matching du rome + home URL si 0 résultats + Post MEP pe.fr > check diff perf autocomplete métier dans opbeat

je vais faire une (lourde) demande de MAJ de la doc API à l'ESD, la voici pour info (still work in progress): https://www.evernote.com/l/ABJZCpd2o7lGiacbKbbq3gpvWjr1LOLQrss