### PR TITLE
Get rid of logstash logging

### DIFF
--- a/labonneboite/conf/common/settings_common.py
+++ b/labonneboite/conf/common/settings_common.py
@@ -67,9 +67,6 @@ CONTRACT_VALUES = {'all': 0, 'alternance': 1}
 
 ES_INDEX = 'labonneboite'
 
-LOGSTASH_HOST = "localhost"
-LOGSTASH_PORT = 5959
-
 TILE_SERVER_URL = "http://openmapsurfer.uni-hd.de/tiles/roads/x={x}&y={y}&z={z}"
 
 ROME_NAF_PROBABILITY_CUTOFF = 0.05
@@ -101,4 +98,3 @@ elif get_current_env() == ENV_PRODUCTION:
     from .overrides.production import *
 else:
     raise Exception("unknown environment")
-

--- a/labonneboite/web/app.py
+++ b/labonneboite/web/app.py
@@ -11,7 +11,6 @@ from opbeat.handlers.logging import OpbeatHandler
 from social_core import exceptions as social_exceptions
 from social_flask_sqlalchemy.models import init_social
 from werkzeug.contrib.fixers import ProxyFix
-import logstash
 
 # Flask.
 from flask import g, flash, Flask, redirect, render_template, request, session, url_for
@@ -61,11 +60,6 @@ def activate_logging(flask_app):
     http://flask.pocoo.org/docs/0.12/errorhandling/
     """
     formatter = logging.Formatter("%(levelname)s - %(module)s - [%(pathname)s]\n%(message)s")
-
-    # Logstash.
-    logstash_handler = logstash.LogstashHandler(settings.LOGSTASH_HOST, settings.LOGSTASH_PORT)
-    logstash_handler.setFormatter(formatter)
-    flask_app.logger.addHandler(logstash_handler)
 
     # Output logs to stdout (development mode only).
     if settings.DEBUG:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ ipython==3.1.0
 opbeat==3.5.2
 mock==2.0.0
 pylint==1.6.4
-python-logstash==0.4.5
 # profiling tools used in create_index.py
 pycallgraph==1.0.1
 pyprof2calltree==1.4.3


### PR DESCRIPTION
I doubt this was even functional. Logs are first sent to filebeat, and
then to a remote logstash. It is unnecessary to log directly from the
app to logstash.