### PR TITLE
regisb/es-connection-pool

### DIFF
--- a/labonneboite/common/pools.py
+++ b/labonneboite/common/pools.py
@@ -1,0 +1,16 @@
+import elasticsearch
+
+
+class ConnectionPool(object):
+    ELASTICSEARCH_INSTANCE = None
+
+
+def Elasticsearch():
+    """
+    Elasticsearch client singleton. All connections to ES should go through
+    this client, so that we can reuse ES connections and not flood ES with new
+    connections.
+    """
+    if ConnectionPool.ELASTICSEARCH_INSTANCE is None:
+        ConnectionPool.ELASTICSEARCH_INSTANCE = elasticsearch.Elasticsearch()
+    return ConnectionPool.ELASTICSEARCH_INSTANCE

--- a/labonneboite/common/search.py
+++ b/labonneboite/common/search.py
@@ -6,8 +6,8 @@ import logging
 import unidecode
 
 from flask import url_for
-from elasticsearch import Elasticsearch
-from elasticsearch.exceptions import RequestError
+import elasticsearch
+import elasticsearch.exceptions
 from slugify import slugify
 from backports.functools_lru_cache import lru_cache
 
@@ -17,6 +17,7 @@ from labonneboite.common import sorting
 from labonneboite.common import autocomplete
 from labonneboite.common.pagination import OFFICES_PER_PAGE
 from labonneboite.common.models import Office
+from labonneboite.common.pools import Elasticsearch
 from labonneboite.conf import settings
 from labonneboite.common.rome_mobilities import ROME_MOBILITIES
 
@@ -39,6 +40,7 @@ KEY_TO_LABEL_DISTANCES = {
 
 FILTERS = ['naf', 'headcount', 'flag_alternance', 'distance']
 DISTANCE_FILTER_MAX = 3000
+
 
 
 class Location(object):
@@ -681,7 +683,7 @@ def get_companies_from_es_and_db(json_body, sort):
     logger.info("Elastic Search request : %s", json_body)
     try:
         res = es.search(index=settings.ES_INDEX, doc_type="office", body=json_body)
-    except RequestError as e:
+    except elasticsearch.exceptions.RequestError as e:
         # The following ES bug is known and has been fixed in ES 2.1.0
         # https://github.com/elastic/elasticsearch/pull/13060
         # however as of Jan 2018 we are using Elasticsearch 1.7 so we have to live with it.

--- a/labonneboite/tests/app/test_synchro.py
+++ b/labonneboite/tests/app/test_synchro.py
@@ -3,9 +3,9 @@
 import random
 import unittest
 
-from elasticsearch import Elasticsearch
 from sqlalchemy import create_engine
 
+from labonneboite.common.pools import Elasticsearch
 from labonneboite.common.database import db_session, get_db_string
 from labonneboite.common.database import ENGINE_PARAMS, REAL_DATABASE
 from labonneboite.common.models import Office

--- a/labonneboite/web/health/util.py
+++ b/labonneboite/web/health/util.py
@@ -1,5 +1,5 @@
-from elasticsearch import Elasticsearch
 from labonneboite.common.database import db_session  # This is how we talk to the database.
+from labonneboite.common.pools import Elasticsearch
 
 
 def is_db_alive():


### PR DESCRIPTION
Previously, we were using a new ES connection in each function call.
This was causing Elasticsearch "Failed to establish a new connection"
errors under heavy load. Here, we re-use connections by sharing a common
client in every process.

This should close error
https://opbeat.com/labonneboite/lbb-prod/errors/2909/ (for now)