### PR TITLE
Catch invalid PEAM return values

### DIFF
--- a/labonneboite/web/auth/backends/exceptions.py
+++ b/labonneboite/web/auth/backends/exceptions.py
@@ -1,0 +1,5 @@
+import social_core.exceptions
+
+
+class AuthFailedMissingReturnValues(social_core.exceptions.AuthException):
+    pass


### PR DESCRIPTION
Sometimes, PEAM answers with missing values (gender, first name, ...).
In such cases, we should not crash with a KeyError, but catch the error
and signal it to the user.

For now, we also log the error because we want to be warned.

This will suppress https://opbeat.com/labonneboite/lbb-prod/errors/57/