### PR TITLE
Fix API test (broken by the add of raison_sociale in API result)

### DIFF
--- a/labonneboite/tests/web/api/test_api_base.py
+++ b/labonneboite/tests/web/api/test_api_base.py
@@ -156,6 +156,7 @@ class ApiBaseTest(DatabaseTest):
             {
                 'naf': u'7320Z',  # Map to ROME D1405.
                 'siret': u'00000000000001',
+                'company_name': u'Raison sociale 1',
                 'score': 68,
                 'score_alternance': 18,
                 'headcount': 11,
@@ -489,7 +490,7 @@ class ApiBaseTest(DatabaseTest):
                 raise ValueError("Cannot create an entry in Office with a city absent from self.positions.")
 
             office = Office(
-                company_name=doc['name'],
+                office_name=doc['name'],
                 siret=doc['siret'],
                 score=doc['score'],
                 naf=doc['naf'],
@@ -497,6 +498,7 @@ class ApiBaseTest(DatabaseTest):
                 zipcode=zip_code,
                 email=u'foo@bar.com',
                 departement=zip_code[:2],
+                company_name=doc['company_name'] if 'company_name' in doc else '',
                 flag_alternance=doc['flag_alternance'],
                 headcount=doc['headcount'],
                 x=doc['locations'][0]['lon'],

--- a/labonneboite/tests/web/api/test_api_office_details.py
+++ b/labonneboite/tests/web/api/test_api_office_details.py
@@ -18,6 +18,7 @@ class ApiOfficeDetailsTest(ApiBaseTest):
             u'siret': u'00000000000001',
             u'naf': u'7320Z',
             u'name': u'OFFICE 1',
+            u'raison_sociale': u'Raison sociale 1',
             u'naf_text': u'\xc9tudes de march\xe9 et sondages',
             u'url': u'http://%s/00000000000001/details' % self.TEST_SERVER_NAME,
             u'lon': 6.0,


### PR DESCRIPTION
Réparation des tests unitaires dans test_api
Le problème venait d'un assertDictEquals() qui avec, l'ajout de la raison_sociale n'est plus _equals_ !