### PR TITLE
Hotfix : can't create OfficeAdminUpdate

### DIFF
--- a/labonneboite/web/admin/views/office_admin_update.py
+++ b/labonneboite/web/admin/views/office_admin_update.py
@@ -298,7 +298,7 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
 
 
         # Get company
-        first_office = Office.query.filter_by(siret=sirets[0]).first()
+        first_office = Office.query.filter_by(siret=sirets[0]).first() if sirets else None
 
         # Codes ROMES to boost or to add
         if is_valid and form.data.get('romes_to_boost'):


### PR DESCRIPTION
Correction d'une erreur lors de la création d'une nouvelle fiche de modification...

Origine: Mauvais réflexe => aller au plus rapide et modifier une fiche existante plutôt d'en créer une... Les soucis en cas de création m'échappe... ! :anguished: