### PR TITLE
Add endpoint to convert city_id to slug

### DIFF
--- a/labonneboite/tests/app/test_slug.py
+++ b/labonneboite/tests/app/test_slug.py
@@ -86,3 +86,29 @@ class SlugDetailsTest(AppTest):
             self.assertEqual(data['city']['name'], u'Nantes')
             self.assertEqual(data['city']['latitude'], 47.235456880128645)
             self.assertEqual(data['city']['longitude'], -1.5498348824858057)
+
+
+class CityCodeDetailsTest(AppTest):
+
+    def test_ok_city_code(self):
+        with self.test_request_context:
+            rv = self.app.get('{}?city-code={}'.format(
+                url_for("search.city_code_details"),
+                '44109',
+            ))
+            self.assertEqual(rv.status_code, 200)
+            data = json.loads(rv.data)
+            self.assertEqual(data['city']['name'], u'Nantes')
+            self.assertEqual(data['city']['slug'], u'nantes-44000')
+            self.assertEqual(data['city']['latitude'], 47.235456880128645)
+            self.assertEqual(data['city']['longitude'], -1.5498348824858057)
+
+
+    def test_error_if_invalid_city_code(self):
+        with self.test_request_context:
+            rv = self.app.get('{}?city-code={}'.format(
+                url_for("search.city_code_details"),
+                'INVALID_CODE',
+            ))
+            self.assertEqual(rv.status_code, 400)
+            self.assertEqual(rv.data, 'no city found associated to the code INVALID_CODE')

--- a/labonneboite/web/search/views.py
+++ b/labonneboite/web/search/views.py
@@ -84,7 +84,6 @@ def city_slug_details():
     Endpoint used by La Bonne Alternance only.
 
     Required parameter:
-
         city-slug (str): must take the form "slug-zipcode"
 
     Note that if the slug does not match the zipcode, the returned result will be incorrect.
@@ -106,6 +105,32 @@ def city_slug_details():
         'name': city_location.name,
         'longitude': city_location.location.longitude,
         'latitude': city_location.location.latitude,
+    }
+    return make_response(json.dumps(result))
+
+
+@searchBlueprint.route('/city_code_details')
+def city_code_details():
+    """
+    Endpoint used by La Bonne Alternance only.
+    Required parameter:
+        city-code (str)
+    """
+    result = {}
+
+    city_code = request.args.get('city-code', '')
+    if not city_code:
+        return u'no city-code given', 400
+
+    city = geocoding.get_city_by_commune_id(city_code)
+    if not city:
+        return u'no city found associated to the code {}'.format(city_code), 400
+
+    result['city'] = {
+        'name': city['name'],
+        'slug': '{}-{}'.format(city['slug'], city['zipcode']),
+        'longitude': city['coords']['lon'],
+        'latitude': city['coords']['lat'],
     }
 
     return make_response(json.dumps(result))


### PR DESCRIPTION
Bob Emploi souhaite avoir une URL du type : https://labonnealternance.pole-emploi.fr/entreprises/commune/69123/rome/D1102

Toutefois, il n'existe pas dans LBB d'_endpoint_ pour convertir un code commune vers un _slug_ que je pourrais exploiter dans LBA.... 