### PR TITLE
Allow only some file extensions for Tilkee upload

### DIFF
--- a/labonneboite/web/static/js/tilkee.js
+++ b/labonneboite/web/static/js/tilkee.js
@@ -34,8 +34,17 @@
         });
         $tilkeeModal.find("[name='files']").on("change", function(e){
             var newfiles = $(this).prop("files");
+            // FIXME duplicate code from tilkee/utils.py
+            var allowedExtensions = ['.doc', '.docx', '.jpeg', '.jpg', '.mov', '.mp4', '.pdf', '.png'];
             for (var f = 0; f < newfiles.length; f++) {
-                files.push(newfiles[f]);
+                var filename = newfiles[f].name;
+                var fileExt = '.' + filename.split('.').pop().toLowerCase();
+                if (allowedExtensions.indexOf(fileExt) < 0) {
+                    // Yes, this is a js alert which is ugly
+                    alert("Format de document non autorisé pour le fichier " + filename);
+                } else {
+                    files.push(newfiles[f]);
+                }
             }
             drawFileList(files, siret);
         });

--- a/labonneboite/web/templates/tilkee/upload.html
+++ b/labonneboite/web/templates/tilkee/upload.html
@@ -16,5 +16,6 @@ application/vnd.openxmlformats-officedocument.wordprocessingml.document">
             <a class="btn btn-hollow tilkee-file-select">Sélectionner une pièce jointe</a>
             <button class="btn hidden" type="submit">Créer mon dossier</button>
         </div>
+        <p>Types de fichier supportés : {% for ext in file_extensions %}{{ ext }}{% if not loop.last %}, {% endif %}{% endfor %}</p>
     </form>
 </div>

--- a/labonneboite/web/tilkee/utils.py
+++ b/labonneboite/web/tilkee/utils.py
@@ -5,7 +5,7 @@ import requests
 from labonneboite.conf import settings
 
 
-TILKEE_HTTP_TIMEOUT_SECONDS = 10
+TILKEE_HTTP_TIMEOUT_SECONDS = 20
 AWS_HTTP_TIMEOUT_SECONDS = 40
 
 # FIXME duplicate code from tilkee.js

--- a/labonneboite/web/tilkee/utils.py
+++ b/labonneboite/web/tilkee/utils.py
@@ -1,3 +1,5 @@
+import os
+
 import requests
 
 from labonneboite.conf import settings
@@ -5,6 +7,18 @@ from labonneboite.conf import settings
 
 TILKEE_HTTP_TIMEOUT_SECONDS = 10
 AWS_HTTP_TIMEOUT_SECONDS = 40
+
+# FIXME duplicate code from tilkee.js
+ALLOWED_FILE_EXTENSIONS = (
+    '.doc',
+    '.docx',
+    '.jpeg',
+    '.jpg',
+    '.mov',
+    '.mp4',
+    '.pdf',
+    '.png',
+)
 
 
 def process(files, company, user):
@@ -137,6 +151,13 @@ def request(endpoint, method, **kwargs):
         raise TilkeeError(message)
 
     return response
+
+
+def is_allowed(filename):
+    """
+    Check whether a filename is supported by Tilkee.
+    """
+    return os.path.splitext(filename).lower() in ALLOWED_FILE_EXTENSIONS
 
 
 class TilkeeError(Exception):

--- a/labonneboite/web/tilkee/views.py
+++ b/labonneboite/web/tilkee/views.py
@@ -29,11 +29,18 @@ def upload():
         return render_template(error_template, login_url=login_url)
 
     if request.method == 'GET':
-        return render_template("tilkee/upload.html", company=company)
+        return render_template("tilkee/upload.html", company=company, file_extensions=utils.ALLOWED_FILE_EXTENSIONS)
 
-    files = request.files.getlist('files')
+    return upload_files(company, request.files.getlist('files'))
+
+
+def upload_files(company, files):
     if not files:
         return u'Aucun fichier sélectionné', 400
+    for f in files:
+        filename = f.filename
+        if not utils.is_allowed(filename):
+            return u'Fichier non supporté: {}'.format(filename), 400
 
     try:
         project_url = utils.process(files, company, current_user)


### PR DESCRIPTION
The html input element for file selection in the Tilkee upload form
already contains an "accept" attribute that is supposed to limit the
file types uploaded to Tilkee. However, this attribute is not supported
by Edge and Safari. Thus, we manually enforce file types on the client
side and the server side.