### PR TITLE
Make tilkee compatible with Edge browser

### DIFF
--- a/labonneboite/web/static/js/tilkee.js
+++ b/labonneboite/web/static/js/tilkee.js
@@ -86,7 +86,7 @@
 
     function uploadDocuments($form, siret, files) {
         var formData = new FormData();
-        formData.set("csrf_token", $form.find("[name='csrf_token']")[0].value);
+        formData.append("csrf_token", $form.find("[name='csrf_token']")[0].value);
         for (var f = 0; f < files.length; f++) {
             formData.append('files', files[f], files[f].name);
         }


### PR DESCRIPTION
FormData.set property is not compatible with Edge:
https://developer.mozilla.org/en-US/docs/Web/API/FormData/set

This was causing the "Créer votre candidature" button to be
unresponsive.