### PR TITLE
Fix TypeError raised on exception raising

### DIFF
--- a/labonneboite/web/auth/backends/peam.py
+++ b/labonneboite/web/auth/backends/peam.py
@@ -66,8 +66,8 @@ class PEAMOpenIdConnect(PEAMOAuth2, OpenIdConnectAuth):
                 'first_name': response['given_name'],
                 'last_name': response['family_name'],
             }
-        except KeyError:
+        except KeyError as e:
             # Sometimes PEAM responds without the user details.
-            raise AuthFailedMissingReturnValues
+            raise AuthFailedMissingReturnValues(*e.args)
 
 # pylint:enable=abstract-method


### PR DESCRIPTION
While raising AuthFailedMissingReturnValues, we were not passing enough
arguments to the exception constructor.