### PR TITLE
Fix ignored save modifications in API and FrontEnd

### DIFF
--- a/labonneboite/common/models/office.py
+++ b/labonneboite/common/models/office.py
@@ -175,7 +175,7 @@ class Office(FinalOfficeMixin, CRUDMixin, Base):
             'siret': self.siret,
             'stars': self.get_stars_for_rome_code(rome_code, hiring_type),
             'url':  self.get_url_for_rome_code(rome_code, alternance, **extra_query_string),
-            'contact_mode': self.contact_mode or util.get_contact_mode_for_rome_and_naf(rome_code, self.naf),
+            'contact_mode': util.get_contact_mode_for_rome_and_office(rome_code, self),
             'social_network': self.social_network or '',
             'alternance': self.qualifies_for_alternance(),
         }

--- a/labonneboite/common/search.py
+++ b/labonneboite/common/search.py
@@ -766,7 +766,7 @@ def get_companies_from_es_and_db(json_body, sort, rome_codes, hiring_type):
             company.boost = bool(romes_intersection)
 
         # Set contact mode and position
-        company.contact_mode = util.get_contact_mode_for_rome_and_naf(rome_code_for_contact_mode, company.naf)
+        company.contact_mode = util.get_contact_mode_for_rome_and_office(rome_code_for_contact_mode, company)
 
     try:
         aggregations = res['aggregations']

--- a/labonneboite/common/util.py
+++ b/labonneboite/common/util.py
@@ -113,8 +113,11 @@ def is_safe_url(url, allowed_hosts=None):
     return (not scheme or scheme in valid_schemes)
 
 
-def get_contact_mode_for_rome_and_naf(rome, naf):
-    naf_prefix = naf[:2]
+def get_contact_mode_for_rome_and_office(rome, office):
+    if office.contact_mode:
+        return office.contact_mode
+
+    naf_prefix = office.naf[:2]
     naf_prefix_to_rome_to_contact_mode = load_contact_modes()
     try:
         return naf_prefix_to_rome_to_contact_mode[naf_prefix][rome]

--- a/labonneboite/tests/app/test_contact_mode.py
+++ b/labonneboite/tests/app/test_contact_mode.py
@@ -3,6 +3,7 @@ import unittest
 
 from labonneboite.common import util
 from labonneboite.common.load_data import load_contact_modes
+from labonneboite.common.models import Office
 
 class ContactModeTest(unittest.TestCase):
 
@@ -13,30 +14,44 @@ class ContactModeTest(unittest.TestCase):
         contact_mode_dict = load_contact_modes()
 
         # Case 1 : naf and rome are in contact_mode mapping
+        office1 = Office()
         rome = u'H2504'
-        naf = u'1712Z'
-        naf_prefix = naf[:2]
+        office1.naf = u'1712Z'
+        naf_prefix = office1.naf[:2]
 
         self.assertIn(naf_prefix, contact_mode_dict)
         self.assertIn(rome, contact_mode_dict[naf_prefix])
-        contact_mode = util.get_contact_mode_for_rome_and_naf(rome, naf)
+        contact_mode = util.get_contact_mode_for_rome_and_office(rome, office1)
         self.assertEqual(contact_mode, u'Se présenter spontanément')
 
         # Case 2 : naf is in contact_mode mapping but rome is not
+        office2 = Office()
         rome = u'D1408'
-        naf = u'1712Z'
-        naf_prefix = naf[:2]
+        office2.naf = u'1712Z'
+        naf_prefix = office2.naf[:2]
 
         self.assertIn(naf_prefix, contact_mode_dict)
         self.assertNotIn(rome, contact_mode_dict[naf_prefix])
-        contact_mode = util.get_contact_mode_for_rome_and_naf(rome, naf)
+        contact_mode = util.get_contact_mode_for_rome_and_office(rome, office2)
         self.assertEqual(contact_mode, u'Se présenter spontanément')
 
         # Case 3 : naf is not in contact_mode mapping
+        office3 = Office()
         rome = u'D1408'
-        naf = u'9900Z'
-        naf_prefix = naf[:2]
+        office3.naf = u'9900Z'
+        naf_prefix = office3.naf[:2]
 
         self.assertNotIn(naf_prefix, contact_mode_dict)
-        contact_mode = util.get_contact_mode_for_rome_and_naf(rome, naf)
+        contact_mode = util.get_contact_mode_for_rome_and_office(rome, office3)
         self.assertEqual(contact_mode, u'Envoyer un CV et une lettre de motivation')
+
+        # Case 4 : custom contact_mode
+        custom_contact_mode = u'Send a Fax'
+
+        office4 = Office()
+        rome = u'D1408'
+        office4.naf = u'1712Z'
+        office4.contact_mode = custom_contact_mode
+
+        contact_mode = util.get_contact_mode_for_rome_and_office(rome, office4)
+        self.assertEqual(contact_mode, custom_contact_mode)

--- a/labonneboite/web/api/views.py
+++ b/labonneboite/web/api/views.py
@@ -93,7 +93,7 @@ def company_list():
             zipcode=zipcode,
             extra_query_string=get_ga_query_string(),
             hiring_type=fetcher.hiring_type,
-        ))
+        ), fetcher.hiring_type == hiring_type_util.ALTERNANCE)
         for company in companies
     ]
 

--- a/labonneboite/web/office/views.py
+++ b/labonneboite/web/office/views.py
@@ -119,7 +119,7 @@ def detail(siret):
     else:
         rome_description = settings.ROME_DESCRIPTIONS[rome]
 
-    contact_mode = util.get_contact_mode_for_rome_and_naf(rome, company.naf)
+    contact_mode = util.get_contact_mode_for_rome_and_office(rome, company)
 
     google_search = "%s+%s" % (company.name.replace(' ', '+'), company.city.replace(' ', '+'))
     google_url = "https://www.google.fr/search?q=%s" % google_search
@@ -212,7 +212,9 @@ def download(siret):
     else:
         dic = detail(siret)
         office = dic['company']
-        dic['stages'] = CONTACT_MODE_STAGES[dic['contact_mode']]
+
+        contact_mode = dic['contact_mode']
+        dic['stages'] = CONTACT_MODE_STAGES.get(contact_mode, [contact_mode])
         dic['date'] = date.today()
 
         # Render pdf file


### PR DESCRIPTION
Ces fix ont pour but :
- Corriger KeyError lors de la génération du PDF
- Prise en compte du mode de contact sur le Front (et pas que API)
- Prise en compte des coordonnées spécifiques alternances dans l'API (et pas que le détails)

review @regisb 