### PR TITLE
vgrange/remove_accessibility_clause

### DIFF
--- a/labonneboite/web/templates/root/cgu.html
+++ b/labonneboite/web/templates/root/cgu.html
@@ -82,10 +82,6 @@
     <h3>6. Responsabilités</h3>
     <ol>
       <li>
-        <h4>Accessibilité et utilisation du service</h4>
-        <p>Pôle emploi ne peut être tenu pour responsable vis-à-vis de l’utilisateur des dommages de toute nature, directs ou indirects, résultant de l’utilisation du site internet <a href="//{{ host }}">{{ host }}</a>, ni de l’impossibilité d’y accéder.</p>
-      </li>
-      <li>
         <h4>Résultats de recherche</h4>
         <p>Pôle emploi décline toute responsabilité, envers l’utilisateur et/ou envers les entreprises ou organismes, concernant notamment :</p>
         <ul>


### PR DESCRIPTION
Remove accessibility clause in CGU as Pole Emploi is responsible for accessibility of its websites.


As requested today by Marion@Clara