### PR TITLE
Verify SSL certificates in HTTPS calls

### DIFF
--- a/labonneboite/common/geocoding/datagouv.py
+++ b/labonneboite/common/geocoding/datagouv.py
@@ -52,8 +52,7 @@ def get_features(endpoint, **params):
         endpoint (str)
         params (dict): key/value dictionary to pass as query string
     """
-    # FIXME: insecure SSL request because we don't have SNI in production
-    response = requests.get(settings.API_ADRESSE_BASE_URL + endpoint, params=params, verify=False)
+    response = requests.get(settings.API_ADRESSE_BASE_URL + endpoint, params=params)
     if response.status_code >= 400:
         error = 'adresse-api.data.gouv.fr responded with a {} error: {}'.format(
             response.status_code, response.content


### PR DESCRIPTION
In python 2.7.6, we could not verify SSL certificates because SNI
support was missing. Now that we switched to 3.4, we can verify SSL
certificates again.