### PR TITLE
No key error if peam user has no family_name

### DIFF
--- a/labonneboite/web/auth/backends/peam.py
+++ b/labonneboite/web/auth/backends/peam.py
@@ -64,7 +64,7 @@ class PEAMOpenIdConnect(PEAMOAuth2, OpenIdConnectAuth):
                 'external_id': response['sub'],
                 'gender': response['gender'],
                 'first_name': response['given_name'],
-                'last_name': response['family_name'],
+                'last_name': response['family_name'] if 'family_name' in response else None,
             }
         except KeyError as e:
             # Sometimes PEAM responds without the user details.


### PR DESCRIPTION
Correction d'une `AuthFailedMissingReturnValues` (exception d'origine : `KeyError`) si l'utilisateur n'a pas de nom de famille dans son compte Pôle Emploi.