### PR TITLE
Add users connected on pole-emploi.fr to GA

### DIFF
--- a/labonneboite/web/templates/base.html
+++ b/labonneboite/web/templates/base.html
@@ -326,6 +326,7 @@
 
     ga('set', 'dimension1', {{ 1 if pro_version_enabled else 0 }});
     ga('set', 'dimension2', {{ 1 if user.is_authenticated else 0 }});
+    ga('set', 'dimension6', Cookies.get('idutkes')? 1 : 0);
 
   </script>
 


### PR DESCRIPTION
The 'idutkes' cookie given to users after they are connected to their
account on pole-emploi.fr is on the domain '.pole-emploi.fr'. Thus, it
is possible to read this cookie on labonneboite.pole-emploi.fr. By
checking the presence of this cookie, we will be able to detect users
that are connected to their pe.fr account, but who are not pe-connected
yet.