### PR TITLE
Acantin/save linter

### DIFF
--- a/labonneboite/tests/app/test_recruiter_form.py
+++ b/labonneboite/tests/app/test_recruiter_form.py
@@ -124,7 +124,8 @@ class FormContactMailTest(DatabaseTest):
     def test_new_coordinates(self):
         with app.app_context():
             form = create_update_coordinates_form()
-            mail_content = mail.generate_update_coordinates_mail(form, models.UpdateCoordinatesRecruiterMessage.create_from_form(form))
+            recruiter_message = models.UpdateCoordinatesRecruiterMessage.create_from_form(form)
+            mail_content = mail.generate_update_coordinates_mail(form, recruiter_message)
 
             contact_mode_label = forms.CONTACT_MODES_LABELS.get(form.new_contact_mode, '')
             contact_mode_expected = 'Mode de contact à privilégier : {}'.format(contact_mode_label)
@@ -147,10 +148,17 @@ class FormContactMailTest(DatabaseTest):
                 create_office()
 
                 form = create_update_jobs_form()
-                mail_content = mail.generate_update_jobs_mail(form, models.UpdateJobsRecruiterMessage.create_from_form(form))
+                recruiter_message = models.UpdateJobsRecruiterMessage.create_from_form(form)
+                mail_content = mail.generate_update_jobs_mail(form, recruiter_message)
 
-                self.assertIn('Romes à ajouter LBB : <ul><li>Ecriture d\'ouvrages, de livres (E1102)</li></ul>', mail_content)
-                self.assertIn('Romes à ajouter LBA : <ul><li>Ecriture d\'ouvrages, de livres (E1102)</li></ul>', mail_content)
+                self.assertIn(
+                    'Romes à ajouter LBB : <ul><li>Ecriture d\'ouvrages, de livres (E1102)</li></ul>',
+                    mail_content
+                )
+                self.assertIn(
+                    'Romes à ajouter LBA : <ul><li>Ecriture d\'ouvrages, de livres (E1102)</li></ul>',
+                    mail_content
+                )
 
 
 class CreateFormContactDatabase(DatabaseTest):

--- a/labonneboite/web/app.py
+++ b/labonneboite/web/app.py
@@ -265,7 +265,14 @@ def create_app():
         output='gen/packed.%(version)s.js',
     )
     assets.register('js_all', js)
-    assets.register('recruiter_form', Bundle('js/recruiter-forms.js', filters='jsmin',output='gen/packed.recruiter_form.%(version)s.js',))
+
+    assets.register(
+        'recruiter_form',
+        Bundle('js/recruiter-forms.js',
+        filters='jsmin',
+        output='gen/packed.recruiter_form.%(version)s.js',)
+    )
+
     css = Bundle(
         # LBB.
         'css/_base.css',  # Order is important.

--- a/labonneboite/web/contact_form/forms.py
+++ b/labonneboite/web/contact_form/forms.py
@@ -1,12 +1,11 @@
 # coding: utf8
-from flask import flash
-from flask import redirect, request, url_for
+from flask import request
 
 from flask_wtf import FlaskForm
-from wtforms import BooleanField, StringField, SelectField, TextAreaField, HiddenField, RadioField, SelectMultipleField
+from wtforms import BooleanField, StringField, TextAreaField, HiddenField, RadioField
 from wtforms import validators
 from wtforms.fields.html5 import EmailField, TelField
-from wtforms.validators import DataRequired, Email, Optional, Regexp, URL
+from wtforms.validators import DataRequired, Email, Optional, Regexp, URL, Length
 
 from labonneboite.common.load_data import ROME_CODES
 
@@ -18,6 +17,8 @@ CONTACT_MODES = (
     ('website', 'Via votre site internet'),
 )
 CONTACT_MODES_LABELS = dict(CONTACT_MODES)
+PHONE_REGEX = "^(0|\+33)[1-9]([-. ]?[0-9]{2}){4}$"
+
 
 class OfficeIdentificationForm(FlaskForm):
     siret = StringField(
@@ -31,20 +32,40 @@ class OfficeIdentificationForm(FlaskForm):
 
     last_name = StringField('Nom *', validators=[DataRequired()])
     first_name = StringField('Prénom *', validators=[DataRequired()])
-    phone = TelField('Téléphone *', validators=[DataRequired()], render_kw={"placeholder": "01 77 86 39 49, +33 1 77 86 39 49"})
-    email = EmailField('Adresse email *', validators=[DataRequired(), Email()], render_kw={"placeholder": "exemple@domaine.com"})
+    phone = TelField(
+        'Téléphone *',
+        validators=[DataRequired(), Regexp(PHONE_REGEX)],
+        render_kw={"placeholder": "01 77 86 39 49, +331 77 86 39 49"}
+    )
+    email = EmailField(
+        'Adresse email *',
+        validators=[DataRequired(), Email()],
+        render_kw={"placeholder": "exemple@domaine.com"}
+    )
 
 
 class OfficeHiddenIdentificationForm(FlaskForm):
     siret = HiddenField('Siret *', validators=[DataRequired()])
     last_name = HiddenField('Nom *', validators=[DataRequired()])
     first_name = HiddenField('Prénom *', validators=[DataRequired()])
-    phone = HiddenField('Téléphone *', validators=[DataRequired()], render_kw={"placeholder": "01 77 86 39 49, +33 1 77 86 39 49"})
-    email = HiddenField('Adresse email *', validators=[DataRequired(), Email()], render_kw={"placeholder": "exemple@domaine.com"})
+    phone = HiddenField(
+        'Téléphone *',
+        validators=[DataRequired(), Regexp(PHONE_REGEX)],
+        render_kw={"placeholder": "01 77 86 39 49, +331 77 86 39 49"}
+    )
+    email = HiddenField(
+        'Adresse email *',
+        validators=[DataRequired(), Email()],
+        render_kw={"placeholder": "exemple@domaine.com"}
+    )
 
 
 class OfficeOtherRequestForm(OfficeHiddenIdentificationForm):
-    comment = TextAreaField('Votre message*', [DataRequired(), validators.length(max=15000)], description="15000 caractères maximum")
+    comment = TextAreaField(
+        'Votre message*',
+        validators=[DataRequired(), validators.length(max=15000)],
+        description="15000 caractères maximum"
+    )
 
 
 class OfficeUpdateJobsForm(OfficeHiddenIdentificationForm):
@@ -54,17 +75,41 @@ class OfficeUpdateJobsForm(OfficeHiddenIdentificationForm):
 class OfficeUpdateCoordinatesForm(OfficeHiddenIdentificationForm):
     # Note : we add new_ to avoid conflict with request.args
     new_contact_mode = RadioField('Mode de contact à privilégier', choices=CONTACT_MODES, default='email')
-    new_website = StringField('Site Internet', validators=[URL(), Optional()], render_kw={"placeholder": "http://exemple.com"})
-    new_email = EmailField('Email recruteur', validators=[Email(), Optional()], render_kw={"placeholder": "exemple@domaine.com"})
-    new_phone = StringField('Téléphone', validators=[Optional()], render_kw={"placeholder": "01 77 86 39 49, +33 1 77 86 39 49"})
+    new_website = StringField(
+        'Site Internet',
+        validators=[URL(), Optional()], render_kw={"placeholder": "http://exemple.com"}
+    )
+    new_email = EmailField(
+        'Email recruteur',
+        validators=[Email(), Optional()], render_kw={"placeholder": "exemple@domaine.com"}
+    )
+    new_phone = StringField(
+        'Téléphone',
+        validators=[Optional(), Regexp(PHONE_REGEX)],
+        render_kw={"placeholder": "01 77 86 39 49, +331 77 86 39 49"}
+    )
     social_network = StringField('Réseau social', validators=[URL(), Optional()])
-    new_email_alternance = EmailField('Email recruteur spécialisé alternance', validators=[validators.optional(), Email()], render_kw={"placeholder": "exemple-alternance@domaine.com"})
-    new_phone_alternance = StringField('Téléphone du recruteur spécialisé alternance', validators=[validators.optional()], render_kw={"placeholder": "01 77 86 39 49, +33 1 77 86 39 49"})
+    new_email_alternance = EmailField(
+        'Email recruteur spécialisé alternance',
+        validators=[validators.optional(), Email()],
+        render_kw={"placeholder": "exemple-alternance@domaine.com"}
+    )
+    new_phone_alternance = StringField(
+        'Téléphone du recruteur spécialisé alternance',
+        validators=[validators.optional(), Regexp(PHONE_REGEX)],
+        render_kw={"placeholder": "01 77 86 39 49, +331 77 86 39 49"}
+    )
 
 
 class OfficeRemoveForm(OfficeHiddenIdentificationForm):
-    remove_lbb = BooleanField('Supprimer mon entreprise du service La Bonne Boite puisque je ne suis pas intéressé-e pour recevoir des candidatures spontanées via ce site', [validators.optional()])
-    remove_lba = BooleanField('Supprimer mon entreprise du service La Bonne Alternance puisque je ne suis pas intéressé-e pour recevoir des candidatures spontanées via ce site', [validators.optional()])
+    remove_lbb = BooleanField(
+        'Supprimer mon entreprise du service La Bonne Boite puisque je ne suis pas intéressé-e pour recevoir des candidatures spontanées via ce site',
+        [validators.optional()]
+    )
+    remove_lba = BooleanField(
+        'Supprimer mon entreprise du service La Bonne Alternance puisque je ne suis pas intéressé-e pour recevoir des candidatures spontanées via ce site',
+        [validators.optional()]
+    )
 
 
 def compute_romes():

--- a/labonneboite/web/contact_form/mail.py
+++ b/labonneboite/web/contact_form/mail.py
@@ -10,7 +10,6 @@ from labonneboite.common.email_util import MandrillClient
 from labonneboite.common.models import Office, OfficeAdminAdd, OfficeAdminRemove, OfficeAdminUpdate
 from labonneboite.common import models
 from labonneboite.web.contact_form import forms
-from labonneboite.common.load_data import ROME_CODES
 
 def compute_action_name(form):
     form_to_action = {
@@ -189,8 +188,8 @@ def make_save_suggestion(form, recruiter_message, recruiter_message_type):
         if office_admin_remove:
             url = url_for("officeadminremove.edit_view", id=office_admin_remove.id, _external=True, **params)
             return "Entreprise retirée via Save : <a href='{}'>Voir la fiche de suppression</a>".format(url)
-        else:
-            return 'Aucune entreprise trouvée avec le siret {}'.format(form.siret.data)
+
+        return 'Aucune entreprise trouvée avec le siret {}'.format(form.siret.data)
 
     # OfficeAdminAdd already exists ?
     office_admin_add = OfficeAdminAdd.query.filter_by(siret=form.siret.data).first()
@@ -199,7 +198,10 @@ def make_save_suggestion(form, recruiter_message, recruiter_message_type):
         return "Entreprise créée via Save : <a href='{}'>Voir la fiche d'ajout</a>".format(url)
 
     # OfficeAdminUpdate already exits ?
-    office_admin_update = OfficeAdminUpdate.query.filter(OfficeAdminUpdate.sirets.like("%{}%".format(form.siret.data))).first()
+    office_admin_update = OfficeAdminUpdate.query.filter(
+        OfficeAdminUpdate.sirets.like("%{}%".format(form.siret.data))
+    ).first()
+
     if office_admin_update:
         url = url_for("officeadminupdate.edit_view", id=office_admin_update.id, _external=True, **params)
         return "Entreprise modifiée via Save : <a href='{}'>Voir la fiche de modification</a>".format(url)

--- a/labonneboite/web/office/views.py
+++ b/labonneboite/web/office/views.py
@@ -6,8 +6,8 @@ import os
 from slugify import slugify
 from sqlalchemy.orm.exc import NoResultFound
 
-from flask import abort, redirect, render_template, flash, jsonify
-from flask import Blueprint, current_app
+from flask import abort, render_template, jsonify
+from flask import Blueprint
 from flask import make_response, send_file
 from flask import request, session
 

--- a/labonneboite/web/static/js/recruiter-forms.js
+++ b/labonneboite/web/static/js/recruiter-forms.js
@@ -42,7 +42,7 @@
     $tr.addClass('removed');
     $nestedInputs.each(function(index, el) { $(el).prop('checked', false); });
     $hideInput.prop('checked', true);
-    $input.text('Restaurer');
+    $input.text('Rajouter');
   }
 
   function enableRow($tr, checkAll) {

--- a/labonneboite/web/templates/base.html
+++ b/labonneboite/web/templates/base.html
@@ -237,8 +237,8 @@
       window.CSRF_TOKEN = "{{ csrf_token() }}";
   </script>
 
-  {% assets "js_all" %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
   {% block scripts %}{% endblock %}
+  {% assets "js_all" %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
 
   {% if tilkee_enabled %}
   <script>

--- a/labonneboite/web/templates/contact_form/change_job_infos.html
+++ b/labonneboite/web/templates/contact_form/change_job_infos.html
@@ -1,6 +1,6 @@
 {% if use_lba_template %} {% extends 'base_lba.html' %} {% else %} {% extends 'base.html' %} {% endif %}
 
-{% block scripts %}
+{% block footer_scripts %}
   {% assets "recruiter_form" %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
 {% endblock %}
 

--- a/labonneboite/web/templates/contact_form/form.html
+++ b/labonneboite/web/templates/contact_form/form.html
@@ -6,7 +6,7 @@
 
 {% block title %}{{ title }}{% endblock %}
 
-{% block scripts %}
+{% block footer_scripts %}
   {% assets "recruiter_form" %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
 {% endblock %}
 


### PR DESCRIPTION
Changements notables:
 - Passe linter (Line too long etc...)
 - Remplir automatiquement le nom de l'entreprise dans le formulaire SAVE
 - Rendre le champ 'e-mail' obligatoire si on a coché 'Par email dans le mode de contact (et de même concernant le téléphone et le site internet)
 - Moins de souplesse sur l'acceptation du numéro de téléphone (mais toujours un peu quand même)
 - Retour du `{% block scripts %}{% endblock %}` au-dessus du `js_all`