### PR TITLE
Add extra page to ensure to avoid applications in recruiter form...

### DIFF
--- a/labonneboite/web/contact_form/views.py
+++ b/labonneboite/web/contact_form/views.py
@@ -29,6 +29,25 @@ ERROR_CONTACT_MODE_MESSAGE = 'Vous avez indiqué vouloir être contacté \'{}\' 
 # Get form value from office.contact_mode text
 CONTACT_MODES_LABEL_TO_FORM_VALUE = {v:k for k, v in CONTACT_MODES.items()}
 
+
+@contactFormBlueprint.route('/verification-informations-entreprise', methods=['GET'])
+@contactFormBlueprint.route('/verification-informations-entreprise/<siret>', methods=['GET'])
+def change_info_or_apply_for_job(siret=None):
+    """
+    Ask user if he wants to change company information or apply for a job,
+    in order to avoid the change_info page to be spammed so much by
+    people thinking they are actually applying for a job.
+    """
+    return render_template('contact_form/change_info_or_apply_for_job.html', use_lba_template=is_recruiter_from_lba(), siret=siret)
+
+@contactFormBlueprint.route('/postuler/<siret>', methods=['GET'])
+def apply_for_job(siret):
+    """
+    If user arrives here, it means we successfully avoided having him spam the
+    company modification form. Now we just have to explain him what is wrong.
+    """
+    return render_template('contact_form/apply_for_job.html', siret=siret, use_lba_template=is_recruiter_from_lba())
+
 def create_form(form_class):
     """
     A decorator that inject hidden fields from OfficeHiddenIdentificationForm

--- a/labonneboite/web/static/css/lba-design.css
+++ b/labonneboite/web/static/css/lba-design.css
@@ -63,6 +63,17 @@ a.btn.btn-small {
     font-size: 1.1em;
 }
 
+
+/* Verification form and application-text pages */
+.verification-form, .application-text {
+    background: white;
+    padding: 40px 80px 80px 80px;
+}
+
+.verification-form p, .application-text p {
+    color: #444;
+}
+
 /* Action chooser form */
 .action-chooser-form {
     background: white;

--- a/labonneboite/web/templates/contact_form/apply_for_job.html
+++ b/labonneboite/web/templates/contact_form/apply_for_job.html
@@ -1,0 +1,28 @@
+{% if use_lba_template %}
+    {% extends 'base_lba.html' %}
+{% else %}
+    {% extends 'base.html' %}
+{% endif %}
+
+{% block title %}Postuler dans cette entreprise pour y travailler{% endblock %}
+
+{% block content %}
+<div class="lbb-content">
+    <div class="lbb-single-column-content application-text">
+        <h2>Postuler dans cette entreprise pour y travailler</h2>
+
+        <p>Vous souhaitez postuler auprès de cette entreprise.</p>
+
+        <p>Nous ne proposons pas encore cette fonctionnalité.</p>
+
+        <p>
+            Vous devez donc contacter directement l’entreprise en vous aidant des informations présentes sur
+            {% if use_lba_template %}
+                <a href="https://labonnealternance.pole-emploi.fr/details-entreprises/{{ siret }}" target="_blank">cette page</a>.
+            {% else %}
+                <a href="{{ url_for('office.details', siret=siret) }}" target="_blank">cette page</a>.
+            {% endif %}
+        </p>
+    </div>
+</div>
+{% endblock %}

--- a/labonneboite/web/templates/contact_form/change_info_or_apply_for_job.html
+++ b/labonneboite/web/templates/contact_form/change_info_or_apply_for_job.html
@@ -1,0 +1,34 @@
+{% if use_lba_template %}
+    {% extends 'base_lba.html' %}
+{% else %}
+    {% extends 'base.html' %}
+{% endif %}
+￼
+￼ {% block title %}Demande de modification des informations de mon entreprise{% endblock %}
+￼
+￼ {% block content %}
+￼ <div class="lbb-content">
+￼   <div class="lbb-single-column-content verification-form">
+￼
+￼     <h2>Demande de modification des informations de mon entreprise</h2>
+￼
+￼     <p class="text-center">Veuillez sélectionner votre situation :</p>
+￼
+￼     <p class="text-center">
+        {% if use_lba_template %}
+            <a class="btn btn-large btn-small" href="{{ url_for('contact_form.apply_for_job', siret=siret, origin='labonnealternance') }}">Je souhaite postuler dans cette entreprise pour y travailler.</a>
+        {% else %}
+            <a class="btn btn-large" href="{{ url_for('contact_form.apply_for_job', siret=siret) }}">Je souhaite postuler dans cette entreprise pour y travailler.</a>
+        {% endif %}
+￼     </p>
+￼     <p class="text-center">
+        {% if use_lba_template %}
+￼           <a class="btn btn-small" href="{{ url_for('contact_form.change_info', origin='labonnealternance') }}">￼Je travaille déjà dans cette entreprise et je souhaite modifier ses informations.</a>
+        {% else %}
+    ￼       <a class="btn btn-small" href="{{ url_for('contact_form.change_info') }}">￼Je travaille déjà dans cette entreprise et je souhaite modifier ses informations.</a>
+        {% endif %}
+￼     </p>
+￼
+￼   </div>
+￼ </div>
+￼ {% endblock %}

--- a/labonneboite/web/templates/includes/office_content.html
+++ b/labonneboite/web/templates/includes/office_content.html
@@ -44,7 +44,7 @@
         {% endif %}
 
         <h3 class="lbb-purple">C'est mon entreprise !</h3>
-        <p><a href="{{ url_for('contact_form.change_info', siret=company.siret) }}" target="_blank">Modifier ces informations</a></p>
+        <p><a href="{{ url_for('contact_form.change_info_or_apply_for_job', siret=company.siret) }}" target="_blank">Modifier ces informations</a></p>
 
       </div>
       <div class="grid-col-4">


### PR DESCRIPTION
Sometimes users try to apply to a company in the form dedicated to company if they want to update their information. This causes some extra work for people dealing with these emails.