### PR TITLE
Fix user duplication on authentication

### DIFF
--- a/labonneboite/alembic/versions/c519ecaf1fa6_deduplicate_users.py
+++ b/labonneboite/alembic/versions/c519ecaf1fa6_deduplicate_users.py
@@ -1,0 +1,55 @@
+"""
+deduplicate users
+
+Revision ID: c519ecaf1fa6
+Revises: a6ff4a27b063
+Create Date: 2018-09-26 16:45:13.810694
+"""
+# from alembic import op
+
+import sqlalchemy as sa
+
+
+# Revision identifiers, used by Alembic.
+revision = 'c519ecaf1fa6'
+down_revision = 'a6ff4a27b063'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    try:
+        deduplicate_users()
+    except KeyboardInterrupt:
+        pass
+
+def downgrade():
+    # This migration can be run as many times as we need: just rollback
+    # (alembic downgrade -1) and re-apply (alembic upgrade HEAD).
+    pass
+
+def deduplicate_users():
+    # We import the app to initialize the social models
+    import labonneboite.web.app # pylint: disable=unused-import,unused-variable
+    from labonneboite.common.database import db_session
+    from labonneboite.common.models import auth
+    from labonneboite.common.models.user_favorite_offices import UserFavoriteOffice
+
+
+    # Iterate on duplicated users
+    for user in auth.User.query.group_by('external_id').having(sa.func.count(auth.User.external_id) > 1):
+        duplicate_user_ids = []
+        favorite_count = 0
+        # Create favorites, if necessary
+        for duplicate_user in auth.User.query.filter(auth.User.external_id == user.external_id, auth.User.id != user.id):
+            duplicate_user_ids.append(duplicate_user.id)
+            for favorite in duplicate_user.favorite_offices:
+                _, created = UserFavoriteOffice.get_or_create(user_id=user.id, office_siret=favorite.office_siret)
+                if created:
+                    favorite_count += 1
+
+        print("Removing {} duplicates for user #{} ({} favorite added to original user)".format(len(duplicate_user_ids), user.id, favorite_count))
+        # Remove duplicate social user
+        db_session.query(auth.UserSocialAuth).filter(auth.UserSocialAuth.user_id.in_(duplicate_user_ids)).delete(synchronize_session=False)
+        # Remove duplicate user
+        auth.User.query.filter(auth.User.id.in_(duplicate_user_ids)).delete(synchronize_session=False)

--- a/labonneboite/common/models/auth.py
+++ b/labonneboite/common/models/auth.py
@@ -64,3 +64,18 @@ def get_user_social_auth(user_id):
         .order_by(desc(UserSocialAuth.id))
         .first()
     )
+
+
+def find_user(strategy, details, backend, *args, user=None, **kwargs):
+    """
+    Function designed to be inserted just before replace
+    social_core.pipeline.user.create_user in the social pipeline. We need to
+    search for existing users because we have 2 different authentication
+    backends. If we don't find the user before we call the create_user
+    function, each backend will create a new user. Thus, a single user may be
+    subscribed twice, with different favorites.
+    """
+    user = user or User.query.filter_by(external_id=details.get('external_id')).first()
+    return {
+        'user': user
+    }

--- a/labonneboite/tests/web/front/test_peam_pipeline.py
+++ b/labonneboite/tests/web/front/test_peam_pipeline.py
@@ -1,0 +1,50 @@
+from social_flask.utils import load_strategy
+
+from labonneboite.web.auth.backends import peam
+from labonneboite.tests.test_base import DatabaseTest
+
+
+class AuthPipelineTest(DatabaseTest):
+
+    def run_pipeline(self, BackendClass):
+        with self.test_request_context:
+            strategy = load_strategy()
+            backend = BackendClass(strategy=strategy)
+            pipeline = strategy.get_pipeline(backend)
+            result = backend.run_pipeline(
+                pipeline, pipeline_index=0,
+                backend=backend,
+                is_new=False,
+                response={
+                    'access_token': 'access-token',
+                    'email': 'my@email.com',
+                    'expires_in': 1000,
+                    'given_name': 'ELTON',
+                    'family_name': 'JOHN',
+                    'gender': 'male',
+                    'id_token': 'loooooooongstring',
+                    'nonce': 'longnonce',
+                    'refresh_token': 'refresh-token',
+                    'scope': 'application_PAR_lbb_scope email api_peconnect-individuv1 openid profile',
+                    'sub': 'peconnect-userid',
+                    'token_type': 'Bearer',
+                    'updated_at': '0'
+                },
+                storage=strategy.storage,
+                strategy=strategy,
+                user=None
+            )
+            return result
+
+    def test_run_pipeline_with_PEAMOpenIdConnect(self):
+        result = self.run_pipeline(peam.PEAMOpenIdConnect)
+        self.assertIn('user', result)
+
+    def test_run_pipeline_with_PEAMOpenIdConnectNoPrompt(self):
+        result = self.run_pipeline(peam.PEAMOpenIdConnectNoPrompt)
+        self.assertIn('user', result)
+
+    def test_run_pipeline_twice(self):
+        result1 = self.run_pipeline(peam.PEAMOpenIdConnect)
+        result2 = self.run_pipeline(peam.PEAMOpenIdConnectNoPrompt)
+        self.assertEqual(result1['user'].id, result2['user'].id)

--- a/labonneboite/web/config.py
+++ b/labonneboite/web/config.py
@@ -43,6 +43,21 @@ class Config(object):
         'labonneboite.web.auth.backends.peam.PEAMOpenIdConnectNoPrompt',
     )
 
+    SOCIAL_AUTH_PIPELINE = (
+        'social_core.pipeline.social_auth.social_details',
+        'social_core.pipeline.social_auth.social_uid',
+        'social_core.pipeline.social_auth.auth_allowed',
+        'social_core.pipeline.social_auth.social_user',
+        'social_core.pipeline.user.get_username',
+        # We use the default pipeline (social_core.pipeline.DEFAULT_AUTH_PIPELINE)
+        # with just the additional find_user function.
+        'labonneboite.common.models.auth.find_user',
+        'social_core.pipeline.user.create_user',
+        'social_core.pipeline.social_auth.associate_user',
+        'social_core.pipeline.social_auth.load_extra_data',
+        'social_core.pipeline.user.user_details'
+    )
+
     # PEAM backends config.
     SOCIAL_AUTH_VERIFY_SSL = settings.PEAM_VERIFY_SSL
     SOCIAL_AUTH_KEY = settings.PEAM_CLIENT_ID


### PR DESCRIPTION
After authenticating with our two different backends, we might have two
different users, with different sets of favorites. To solve this, we
modify the social pipeline. We look for an existing user before creating
a new one.

Once we apply this patch, we will need to run a data migration to fix existing duplicate users.