### PR TITLE
Except ConnectionError in send method of MandrillClient

### DIFF
--- a/labonneboite/common/email_util.py
+++ b/labonneboite/common/email_util.py
@@ -3,6 +3,7 @@
 import json
 import logging
 from urllib.error import HTTPError
+from requests.exceptions import ConnectionError
 
 from labonneboite.conf import settings
 
@@ -35,7 +36,7 @@ class MandrillClient(EmailClient):
                 to=[{'email': to_email}],
                 html=html,
                 from_email=from_email)
-        except HTTPError:
+        except (HTTPError, ConnectionError):
             success = False
         else:
             content = response.json()


### PR DESCRIPTION
Sometimes, we failed to connect to Mandrill.  By excepting this error, we can put a error notification to user instead of a generic error page.