### PR TITLE
Fix redirect after je postule application

### DIFF
--- a/labonneboite/web/templates/jepostule/candidater.html
+++ b/labonneboite/web/templates/jepostule/candidater.html
@@ -13,6 +13,8 @@
             var data = e.data;
             if (data.action === "resize") {
                 document.getElementById("jepostule").height = data.value;
+            } else if(data.action === "quit") {
+                window.location = data.label;
             } else {
                 ga('send', 'event', 'jepostule', data.action, data.label, data.value);
             }


### PR DESCRIPTION
When iframe redirects to a different location, it is still in an iframe.
To avoid this problem, we need to listen to events.