### PR TITLE
Auto-adding http:// if missing in save form

### DIFF
--- a/labonneboite/tests/app/test_url.py
+++ b/labonneboite/tests/app/test_url.py
@@ -2,9 +2,10 @@
 import unittest
 
 from labonneboite.common import util
+from labonneboite.web.admin.views.office_admin_update import format_url
 
 
-class SafeUrlTest(unittest.TestCase):
+class UrlTest(unittest.TestCase):
 
     def test_is_safe_url(self):
 
@@ -22,3 +23,18 @@ class SafeUrlTest(unittest.TestCase):
         url = 'http://labonneboite.pole-emploi.fr/entreprises/metz-57000/boucherie?sort=score&d=10&h=1&p=0'
         is_safe_url = util.is_safe_url(url, allowed_hosts={'labonneboite.pole-emploi.fr'})
         self.assertTrue(is_safe_url)
+
+    def test_format_url(self):
+        # Urls modified
+        url = 'www.decathlon.fr'
+        self.assertEquals(format_url(url), 'http://www.decathlon.fr')
+
+        url = 'decathlon.fr'
+        self.assertEquals(format_url(url), 'http://decathlon.fr')
+
+        # Urls not modified
+        url = 'http://www.decathlon.fr'
+        self.assertEquals(format_url(url), url)
+
+        url = 'https://www.decathlon.fr'
+        self.assertEquals(format_url(url), url)

--- a/labonneboite/web/admin/views/office_admin_update.py
+++ b/labonneboite/web/admin/views/office_admin_update.py
@@ -548,6 +548,12 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
 
 
     def validate_form(self, form):
+        # Add http:// is missing
+        form['new_website'].data = format_url(form['new_website'].data)
+        form['social_network'].data = format_url(form['social_network'])
+        form['website_alternance'].data = format_url(form['website_alternance'])
+
+
         is_valid = super(OfficeAdminUpdateModelView, self).validate_form(form)
 
         # All sirets must be well formed
@@ -740,3 +746,9 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
 
 def clean_phone(phone):
     return phone.replace(" ", "").replace(".", "")
+
+def format_url(value):
+    # Auto-adding http:// if missing
+    if value and not value.startswith('http://') and not value.startswith('https://'):
+        return '{}{}'.format('http://', value)
+    return value


### PR DESCRIPTION
Savers don't want to be blocked on validation when they don't add the http(s):// in URLs (social_network-website-website_alternance). So we auto-add it !