### PR TITLE
Attempt to trigger more analytics events for Je Postule

### DIFF
--- a/labonneboite/web/templates/jepostule/candidater.html
+++ b/labonneboite/web/templates/jepostule/candidater.html
@@ -6,7 +6,7 @@
 <iframe id="jepostule" width="100%" height="900px" src="{{ iframe_base }}{{ iframe_path }}" frameborder="0"></iframe>
 {% endblock %}
 
-{% block footer_scripts %}
+{% block extrahead %}
 <script>
     function onReceiveMessage(e) {
         if (e.origin === "{{ iframe_base }}" && e.data.topic === "jepostule") {


### PR DESCRIPTION
Some "navigate" events are not fired. I suspect this is because the
script block is located after the iframe. Here, we move the script
before the iframe as an attempt to capture more events.