### PR TITLE
Add email to sirets + link to create OfficeAdminUpdate in BO

### DIFF
--- a/labonneboite/web/admin/views/office_admin_update.py
+++ b/labonneboite/web/admin/views/office_admin_update.py
@@ -334,6 +334,12 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
     def create_form(self):
         # Call only when a form is created
         form = super(OfficeAdminUpdateModelView, self).create_form()
+
+        # Inject sirets from URL
+        sirets = request.args.get('sirets', '')
+        if sirets:
+            form['sirets'].data = sirets.replace(',','\n')
+
         return self.prefill_form(form)
 
     def on_form_prefill(self, form, id):

--- a/labonneboite/web/data/forms.py
+++ b/labonneboite/web/data/forms.py
@@ -2,7 +2,7 @@
 
 from flask_wtf import FlaskForm
 from wtforms import StringField, ValidationError
-from wtforms.validators import DataRequired
+from wtforms.validators import DataRequired, Email
 
 from labonneboite.common import mapping as mapping_util
 from labonneboite.common.models import Office
@@ -81,3 +81,19 @@ class SiretForm(FlaskForm):
                 raise ValidationError("Ce SIRET n'existe pas.")
             # Set office as a form attribute for easy access in the view and to avoid another query.
             self.office = office
+
+
+class EmailForm(FlaskForm):
+    """
+    Enter a MAIL to find associated SIRETS.
+    """
+    email = StringField("Email", validators=[DataRequired(), Email()],
+        description="Saisissez un email pour trouver les sirets associés.")
+
+    class Meta:
+        # CSRF validation is enabled globally but we don't want the CSRF token
+        # to be included in this form.
+        # The token can be removed safely here because this form is always submitted in GET.
+        # See http://goo.gl/QxWXBH for CSRF token with the GET method: server-side actions
+        # that have state changing affect should only respond to POST requests.
+        csrf = False

--- a/labonneboite/web/templates/data/base.html
+++ b/labonneboite/web/templates/data/base.html
@@ -17,6 +17,10 @@
           {% if current_tab == 'romes_for_siret' %}SIRET/ROME
           {% else %}<a href="{{ url_for('data.romes_for_siret') }}">SIRET/ROME</a>{% endif %}
         </li>
+        <li>
+          {% if current_tab == 'sirets_for_email' %}EMAIL/SIRETS
+          {% else %}<a href="{{ url_for('data.sirets_for_email') }}">EMAIL/SIRETS</a>{% endif %}
+        </li>
     </ol>
 
     {% block data_content %}{% endblock %}

--- a/labonneboite/web/templates/data/sirets_for_email.html
+++ b/labonneboite/web/templates/data/sirets_for_email.html
@@ -1,0 +1,41 @@
+{% extends 'data/base.html' %}
+
+{% block title %}Sirets associés à un e-mail{% endblock %}
+
+{% block data_content %}
+
+<h2>Sirets associés à un e-mail</h2>
+
+<form class="form-vertical" action="" method="get">
+    {% include "includes/form_content.html" %}
+</form>
+
+{% if companies %}
+<table>
+    <caption>
+        Voici la liste des sirets associés à l'email : {{ email }}
+    </caption>
+    <thead>
+        <tr>
+            <th>Siret</th>
+            <th>Nom</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for company in companies %}
+        <tr>
+            <td>{{ company.siret }}</td>
+            <td>{{ company.name }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{% if save_link %}
+<h3>Lien SAVE</h3>
+<a href={{ save_link }}>Lien SAVE</a>
+{% endif %}
+
+{% endif %}
+
+{% endblock %}


### PR DESCRIPTION
Quand un recruteur demande à retirer toutes les entreprises associés à leur email, il en est impossible de les retrouver par eux-mêmes.

Cette PR a pour objectif de leur ajouter cette fonctionnalité mais aussi de créer directement la fiche de modification associée !