### PR TITLE
Extend user authentication to 1 year

### DIFF
--- a/labonneboite/conf/common/settings_common.py
+++ b/labonneboite/conf/common/settings_common.py
@@ -122,6 +122,7 @@ PEAM_AUTH_BASE_URL = 'https://authentification-candidat.pole-emploi.fr'
 PEAM_API_BASE_URL = 'https://api.emploi-store.fr'
 PEAM_TOKEN_BASE_URL = 'https://entreprise.pole-emploi.fr'
 PEAM_VERIFY_SSL = True
+REMEMBER_ME_ARG_NAME = 'keep'
 # Settings that need to be overwritten
 # FIXME there should be a default value for these settings in the code whenever the setting is not defined.
 PEAM_CLIENT_ID = '<set it>'

--- a/labonneboite/web/app.py
+++ b/labonneboite/web/app.py
@@ -29,6 +29,7 @@ from labonneboite.common.models import Office
 from labonneboite.conf import settings
 
 # labonneboite web.
+from labonneboite.web.auth import utils as auth_utils
 from labonneboite.web.auth.backends.exceptions import AuthFailedMissingReturnValues
 from labonneboite.web.config import CONFIG
 from labonneboite.web.jepostule.utils import jepostule_enabled
@@ -191,6 +192,7 @@ def register_context_processors(flask_app):
             'enable_adblock_tracking': settings.ENABLE_ADBLOCK_TRACKING,
             'tilkee_enabled': settings.TILKEE_ENABLED,
             'google_site_verification_code': settings.GOOGLE_SITE_VERIFICATION_CODE,
+            'login_url': auth_utils.login_url,
         }
 
     def inject_user():
@@ -350,7 +352,7 @@ def social_auth_error(error):
     elif isinstance(error, social_exceptions.AuthForbidden):
         # "Your credentials aren't allowed"
         pass
-    elif isinstance(error, social_exceptions.AuthMissingParameter) or isinstance(error, AuthFailedMissingReturnValues):
+    elif isinstance(error, (social_exceptions.AuthMissingParameter, AuthFailedMissingReturnValues)):
         flash_message = "Veuillez vérifier vos emails et procéder à la validation de votre compte Pôle Emploi."
     elif not isinstance(error, (
             social_exceptions.AuthCanceled,

--- a/labonneboite/web/auth/utils.py
+++ b/labonneboite/web/auth/utils.py
@@ -1,0 +1,17 @@
+from urllib.parse import urlencode
+
+from flask import request, url_for
+
+from labonneboite.conf import settings
+
+
+def login_url(next_url=None):
+    querystring = {
+        # This argument tells flask-login that the authentication user id
+        # should be persisted in a cookie
+        settings.REMEMBER_ME_ARG_NAME: '1',
+    }
+    next_url = next_url or (request.url if request else None)
+    if next_url:
+        querystring['next'] = next_url
+    return url_for('social.auth', backend='peam-openidconnect') + '?' + urlencode(querystring)

--- a/labonneboite/web/config.py
+++ b/labonneboite/web/config.py
@@ -2,6 +2,8 @@
 """
 Flask app configuration settings.
 """
+from datetime import timedelta
+
 from labonneboite.conf import settings
 
 
@@ -36,6 +38,11 @@ class Config(object):
     SOCIAL_AUTH_USER_MODEL = 'labonneboite.common.models.auth.User'
     SOCIAL_AUTH_LOGIN_URL = '/'
     SOCIAL_AUTH_INACTIVE_USER_URL = '/'
+
+    # Persist user authentication in cookie, and not just in session
+    SOCIAL_AUTH_FIELDS_STORED_IN_SESSION = [settings.REMEMBER_ME_ARG_NAME] # used by social_core
+    REMEMBER_COOKIE_NAME = 'auth' # used by social_flask and flask_login
+    REMEMBER_COOKIE_DURATION = timedelta(days=365)
 
     # List of supported third party authentication providers.
     SOCIAL_AUTH_AUTHENTICATION_BACKENDS = (

--- a/labonneboite/web/static/js/transparent-sso.js
+++ b/labonneboite/web/static/js/transparent-sso.js
@@ -42,7 +42,7 @@
           // redirect is an url that will signal the parent window (this one)
           // with a USER_SSO_CONNECTED message if the user is correctly connected.
           var iframeUrl = window.location.protocol + '//' + window.location.host + '/authentication/iframe';
-          var peamURL = window.location.origin + '/authorize/login/peam-openidconnect-no-prompt/?next=' + encodeURIComponent(iframeUrl);
+          var peamURL = window.location.origin + '/authorize/login/peam-openidconnect-no-prompt/?keep=1&next=' + encodeURIComponent(iframeUrl);
           var ifr = document.createElement("iframe");
           ifr.setAttribute("src", peamURL);
           ifr.setAttribute("style", "display:none;");

--- a/labonneboite/web/templates/root/cookbook.html
+++ b/labonneboite/web/templates/root/cookbook.html
@@ -46,7 +46,7 @@
           </a>
           <div class="lbb-dropdown lbb-dropdown-right text-right">
             <p>
-              <a class="logo-pe-connect" href="{{ url_for('social.auth', backend='peam-openidconnect') }}?next={{ request.url | urlencode }}"><img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Pôle emploi Connect"></a><br>
+              <a class="logo-pe-connect" href="{{ login_url() }}"><img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Pôle emploi Connect"></a><br>
               <i>Connectez-vous à La Bonne Boite en utilisant des identifiants Pôle emploi. Vous n'avez pas de compte ? Créez-en un et profitez de tous les services dédiés à l'emploi de nos partenaires.</i>
             </p>
           </div>
@@ -80,7 +80,7 @@
           </a>
           <div class="lbb-dropdown lbb-dropdown-right text-right">
             <p>
-              <a class="logo-pe-connect" href="{{ url_for('social.auth', backend='peam-openidconnect') }}?next={{ request.url | urlencode }}"><img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Pôle emploi Connect"></a><br>
+              <a class="logo-pe-connect" href="{{ login_url }}"><img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Pôle emploi Connect"></a><br>
               <i>Connectez-vous à La Bonne Boîte en utilisant des identifiants Pôle emploi. Vous n'avez pas de compte ? Créez-en un et profitez de tous les services dédiés à l'emploi de nos partenaires.</i>
             </p>
           </div>

--- a/labonneboite/web/templates/user/header.html
+++ b/labonneboite/web/templates/user/header.html
@@ -6,7 +6,7 @@
   </a>
   <div class="lbb-dropdown lbb-dropdown-right text-right">
     <p>
-      <a class="logo-pe-connect rgpd-consent-required" href="{{ url_for('social.auth', backend='peam-openidconnect') }}?next={{ (next_url or request.url) | urlencode }}"><img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Pôle emploi Connect"></a><br>
+    <a class="logo-pe-connect rgpd-consent-required" href="{{ login_url(next_url=next_url) }}"><img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Pôle emploi Connect"></a><br>
       <i>Connectez-vous à La Bonne Boite en utilisant des identifiants Pôle emploi. Vous n'avez pas de compte ? Créez-en un et profitez de tous les services dédiés à l'emploi de nos partenaires.</i>
     </p>
   </div>

--- a/labonneboite/web/tilkee/views.py
+++ b/labonneboite/web/tilkee/views.py
@@ -1,12 +1,13 @@
 # coding: utf8
 import logging
 
-from flask import Blueprint, render_template, request, url_for
+from flask import Blueprint, render_template, request
 from flask.helpers import BadRequest
 from flask_login import current_user
 
 from labonneboite.conf import settings
 from labonneboite.common.models.office import Office
+from labonneboite.web.auth.utils import login_url
 from . import utils
 
 
@@ -30,8 +31,7 @@ def upload():
         error_template = "tilkee/missing_email.html"
     if error_template:
         next_url = request.referrer + '#company-{}'.format(company.siret) if request.referrer else ''
-        login_url = url_for('social.auth', backend='peam-openidconnect', next=next_url)
-        return render_template(error_template, login_url=login_url)
+        return render_template(error_template, login_url=login_url(next_url=next_url))
 
     if request.method == 'GET':
         return render_template("tilkee/upload.html", company=company, file_extensions=utils.ALLOWED_FILE_EXTENSIONS)
@@ -60,3 +60,4 @@ def upload_files(company, files):
 def postuler():
     if not current_user.is_authenticated:
         return render_template("tilkee/login.html")
+    return None


### PR DESCRIPTION
Previously, user authentication was persisted in a session cookie. This
caused user disconnection at the end of the session. Here, we extend the
duration of user connection to a year by storing the user id to a "auth"
cookie.