### PR TITLE
Do not display error log if user cancelled the connexion + No 404 after

### DIFF
--- a/labonneboite/web/auth/backends/peam_recruiter.py
+++ b/labonneboite/web/auth/backends/peam_recruiter.py
@@ -8,6 +8,9 @@ from labonneboite.conf import settings
 class PeamRecruiterError(Exception):
     pass
 
+class PeamRecruiterLoginCancelled(Exception):
+    pass
+
 # Recruiter session value keys
 class SessionKeys(Enum):
     EMAIL = 'SESSION_EMAIL'


### PR DESCRIPTION
Quand un recruteur annule sa connexion, nous obtenons une erreur... Ce que l'on ne souhaite pas.
Pire, l'utilisateur est redirigé vers une page qui n'existe pas (erreur 404) dû à un `/` en trop dans l'URL