### PR TITLE
Fix missing recruiter_uid and certified checkbox in SAVE Form

### DIFF
--- a/labonneboite/web/admin/views/office_admin_update.py
+++ b/labonneboite/web/admin/views/office_admin_update.py
@@ -438,6 +438,8 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
         )
         self.handle_diff('requested_by_last_name', recruiter_message.requested_by_last_name, office_admin_update, form)
         self.handle_diff('requested_by_phone', recruiter_phone, office_admin_update, form)
+        self.handle_diff('certified_recruiter', recruiter_message.certified_recruiter, office_admin_update, form)
+        self.handle_diff('recruiter_uid', recruiter_message.recruiter_uid, office_admin_update, form)
 
 
         if recruiter_message_params.type == models.UpdateCoordinatesRecruiterMessage.name:
@@ -452,8 +454,6 @@ class OfficeAdminUpdateModelView(AdminModelViewMixin, ModelView):
             self.handle_diff('social_network', recruiter_message.social_network, office_admin_update, form)
             self.handle_diff('phone_alternance', new_phone_alternance, office_admin_update, form)
             self.handle_diff('email_alternance', recruiter_message.new_email_alternance, office_admin_update, form)
-            self.handle_diff('certified_recruiter', recruiter_message.certified_recruiter, office_admin_update, form)
-            self.handle_diff('recruiter_uid', recruiter_message.recruiter_uid, office_admin_update, form)
             self.handle_diff(
                 'contact_mode',
                 CONTACT_MODES.get(recruiter_message.contact_mode, ''),

--- a/labonneboite/web/contact_form/views.py
+++ b/labonneboite/web/contact_form/views.py
@@ -239,7 +239,11 @@ def update_jobs_form(form):
         })
 
     if form.validate_on_submit():
-        recruiter_message = models.UpdateJobsRecruiterMessage.create_from_form(form)
+        recruiter_message = models.UpdateJobsRecruiterMessage.create_from_form(
+            form,
+            is_certified_recruiter=peam_recruiter.is_certified_recruiter(),
+            uid=peam_recruiter.get_recruiter_uid()
+        )
         mail_content = mail.generate_update_jobs_mail(form, recruiter_message)
 
         try:
@@ -274,7 +278,11 @@ def update_jobs_form(form):
 @create_form(forms.OfficeRemoveForm)
 def delete_form(form):
     if form.validate_on_submit():
-        recruiter_message = models.RemoveRecruiterMessage.create_from_form(form)
+        recruiter_message = models.RemoveRecruiterMessage.create_from_form(
+            form,
+            is_certified_recruiter=peam_recruiter.is_certified_recruiter(),
+            uid=peam_recruiter.get_recruiter_uid()
+        )
         mail_content = mail.generate_delete_mail(form, recruiter_message)
 
         try:
@@ -306,7 +314,11 @@ def delete_form(form):
 @create_form(forms.OfficeOtherRequestForm)
 def other_form(form):
     if form.validate_on_submit():
-        recruiter_message = models.OtherRecruiterMessage.create_from_form(form)
+        recruiter_message = models.OtherRecruiterMessage.create_from_form(
+            form,
+            is_certified_recruiter=peam_recruiter.is_certified_recruiter(),
+            uid=peam_recruiter.get_recruiter_uid()
+        )
         mail_content = mail.generate_other_mail(form, recruiter_message)
 
         try:


### PR DESCRIPTION
L'identifiant du recruteur ainsi que la case a coché ne sont pas remontés dans les formulaires SAVE...
Cette PR corrige ce souci :)