### PR TITLE
Fix fields not disabled on peam recruiter

### DIFF
--- a/labonneboite/web/static/js/recruiter-forms.js
+++ b/labonneboite/web/static/js/recruiter-forms.js
@@ -90,10 +90,6 @@
           $form.find("input[name='last_name']").val(values.lastName);
           $form.find("input[name='first_name']").val(values.firstName);
           $form.find("input[name='email']").val(values.email);
-        } else {
-          $form.find("input[name='last_name']").attr('disabled', 'disabled');
-          $form.find("input[name='first_name']").attr('disabled', 'disabled');
-          $form.find("input[name='email']").attr('disabled', 'disabled');
         }
         $form.find("input[name='phone']").val(values.phone);
       } catch(error) {
@@ -101,6 +97,18 @@
         return;
       }
 
+    }
+  }
+
+  function disablePeamRecruiterFields() {
+    if($('.identification-form').length > 0) {
+      var $form = $('.identification-form');
+      var isConnectedRecruiter = $('[data-esd-recruiter="true"]').length > 0;
+      if(!isConnectedRecruiter) return;
+
+      $form.find("input[name='last_name']").attr('disabled', 'disabled');
+      $form.find("input[name='first_name']").attr('disabled', 'disabled');
+      $form.find("input[name='email']").attr('disabled', 'disabled');
     }
   }
 
@@ -170,6 +178,7 @@
   $(document).on('lbbready', function () {
     initJobFormHandler();
     addLastSubmittedValue();
+    disablePeamRecruiterFields();
   });
 
 })(jQuery);

--- a/labonneboite/web/static/js/recruiter-forms.js
+++ b/labonneboite/web/static/js/recruiter-forms.js
@@ -76,26 +76,28 @@
 
       var rawValues = localStorage.getItem(FORM_STORAGE_KEY);
       if(!rawValues) return;
+
+      var values = {};
       try {
-        var values = JSON.parse(rawValues);
-
-        // Do not override value if the siret (coming from URL parameter) is already here
-        var $siret = $form.find("input[name='siret']");
-        if(!$siret.val()) $siret.val(values.siret);
-
-        // Do not override last_name/first_name/email is data comes from PE Connect
-        var isConnectedRecruiter = $('[data-esd-recruiter="true"]').length > 0;
-
-        if(!isConnectedRecruiter) {
-          $form.find("input[name='last_name']").val(values.lastName);
-          $form.find("input[name='first_name']").val(values.firstName);
-          $form.find("input[name='email']").val(values.email);
-        }
-        $form.find("input[name='phone']").val(values.phone);
+        values = JSON.parse(rawValues);
       } catch(error) {
-        console.log(error)
+        console.log(error);
         return;
       }
+
+      // Do not override value if the siret (coming from URL parameter) is already here
+      var $siret = $form.find("input[name='siret']");
+      if(!$siret.val()) $siret.val(values.siret);
+
+      // Do not override last_name/first_name/email is data comes from PE Connect
+      var isConnectedRecruiter = $('[data-esd-recruiter="true"]').length > 0;
+
+      if(!isConnectedRecruiter) {
+        $form.find("input[name='last_name']").val(values.lastName);
+        $form.find("input[name='first_name']").val(values.firstName);
+        $form.find("input[name='email']").val(values.email);
+      }
+      $form.find("input[name='phone']").val(values.phone);
 
     }
   }


### PR DESCRIPTION
When a recruiter is connected, fields filled with PEAM values should disabled. But actually, the recruiter need to have data in localStorage which have no sense... So, we put this logic in his own function :)