### PR TITLE
Solve timeout errors during jepostule deployments

### DIFF
--- a/labonneboite/web/jepostule/views.py
+++ b/labonneboite/web/jepostule/views.py
@@ -48,7 +48,7 @@ def get_token(**params):
     try:
         response = requests.post(
             settings.JEPOSTULE_BASE_URL + '/auth/application/token/',
-            data=params, timeout=5
+            data=params, timeout=20
         )
     except requests.ReadTimeout:
         raise JePostuleError('Request token timeout')


### PR DESCRIPTION
A timeout of 5s is too low, it causes errors during deployments of je
postule, where the api takes more than 5s to respond (although the
docker upgrade is supposed not to create any downtime).