### PR TITLE
Fix PEAM connection timeouts

### DIFF
--- a/labonneboite/web/config.py
+++ b/labonneboite/web/config.py
@@ -81,4 +81,8 @@ class Config(object):
     # PE.fr, so we need to define a redirect url manually
     SOCIAL_AUTH_PEAM_OPENIDCONNECT_NO_PROMPT_LOGIN_REDIRECT_URL = '/authentication/iframe'
 
+    # Define connection timeouts to make sure LBB is not going to timeout before PEAM
+    SOCIAL_AUTH_PEAM_OPENIDCONNECT_URLOPEN_TIMEOUT = 8
+    SOCIAL_AUTH_PEAM_OPENIDCONNECT_NO_PROMPT_URLOPEN_TIMEOUT = 5
+
 CONFIG = Config()


### PR DESCRIPTION
HTTP requests from LBB to PEAM were performed with a timeout of 30s,
which caused the web servers to timeout at 10s, before PEAM. This caused
LBB unavailability (which is sad).