### PR TITLE
Indicate path to sitemap

### DIFF
--- a/labonneboite/web/static/robots.txt
+++ b/labonneboite/web/static/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 # Disabled to facilitate crawling, this parameter shouldn't be necessary.
 #Crawl-delay: 2 # sets a 2 second time-out
 Disallow: /*/download
+Sitemap: https://labonneboite.pole-emploi.fr/sitemap.xml


### PR DESCRIPTION
Unless I'm mistaken, our sitemap was completely useless because it was
not found by google...

We should measure the impact of this change before/after.