### PR TITLE
Fix datetime in container logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
 FROM ubuntu:18.04
 
+# Set timezone
+ENV TZ=Europe/Paris
+
 # Install system requirements
 ENV LANG C.UTF-8
 RUN apt update && \
-    apt install -y \
+    DEBIAN_FRONTEND=noninteractive apt install -y \
         git \
         libmysqlclient-dev \
         language-pack-fr \
         python3 python3-dev python3-pip \
+        tzdata \
         # scipy
         gfortran libblas-dev liblapack-dev libatlas-base-dev \
     && pip3 install virtualenv


### PR DESCRIPTION
Logs in docker container had their timezone set to UTC. Here we
explicitely set the timezone to Europe/Paris so that the datetime
collected in activity logs is correct.