### PR TITLE
Fix 'More info' button not working on IE11

### DIFF
--- a/labonneboite/web/static/js/map.js
+++ b/labonneboite/web/static/js/map.js
@@ -8,7 +8,7 @@ function createMap(element, center, zoom) {
     zoom: zoom
   });
   mapEl.addControl(new mapboxgl.NavigationControl(), 'top-left');
-  mapEl.addControl(new AttributionControl({ compact: true }));
+  mapEl.addControl(new mapboxgl.AttributionControl({ compact: true }));
   mapEl.scrollZoom.disable();
   return mapEl;
 }
@@ -122,6 +122,11 @@ function createMap(element, center, zoom) {
       ga('send', 'event', 'Carte', 'zoom');
       onMapMove();
     };
+    var onMapLoad = function() {
+      $('.mapboxgl-ctrl-attrib .mapboxgl-ctrl-attrib-inner')
+        .html('<a href="https://www.openstreetmap.org/copyright" target="_blank" title="© Contributeurs OpenStreetMap (ouverture dans un nouvel onglet)">&copy; Contributeurs OpenStreetMap</a>');
+    }
+
 
     var updateMap = function() {
       ga('send', 'event', 'Carte', 'update');
@@ -152,6 +157,7 @@ function createMap(element, center, zoom) {
     };
     map.on('dragend', onMapDrag);
     map.on('zoomend', onMapZoom);
+    map.on('load', onMapLoad);
   }
 
   $(document).on('lbbready', function () {

--- a/labonneboite/web/templates/includes/map-scripts.html
+++ b/labonneboite/web/templates/includes/map-scripts.html
@@ -1,11 +1,1 @@
 <script src="{{ url_for('static', filename='js/vendor/mapbox-gl.0.53.1.js') }}"></script>
-<script>
-    class AttributionControl extends mapboxgl.AttributionControl {
-        //Source: https://github.com/mapbox/mapbox-gl-js/blob/v0.53.1/src/ui/control/attribution_control.js
-        _updateAttributions() {
-            this._innerContainer.innerHTML = '<a href="https://www.openstreetmap.org/copyright" target="_blank" title="© Contributeurs OpenStreetMap (ouverture dans un nouvel onglet)">&copy; Contributeurs OpenStreetMap</a>';
-            this._container.classList.remove('mapboxgl-attrib-empty');
-            this._editLink = null;
-        }
-    }
-</script>


### PR DESCRIPTION
ES6 syntax is not supported by IE 11. So we have to transpiled our code to old JavaScript with Babel (https://babeljs.io/repl) for compatibility purpose.