### PR TITLE
Fix accessibility on home page (mainly)

### DIFF
--- a/labonneboite/web/static/css/_base.css
+++ b/labonneboite/web/static/css/_base.css
@@ -303,3 +303,23 @@ input:disabled {
     background-color: rgb(235, 235, 228);
     cursor: not-allowed;
 }
+
+::placeholder {
+    color:rgb(80,80,80);
+}
+
+
+/* Escape links
+--------------------------------------------------------------------------- */
+a.escape-link {
+   display: inline-block;
+   color: #555;
+   background: #fff;
+   padding: .5em;
+   position: absolute;
+   left: -99999px;
+   z-index: 100;
+}
+a.escape-link:focus {
+   left: 0;
+}

--- a/labonneboite/web/static/css/_global_classes.css
+++ b/labonneboite/web/static/css/_global_classes.css
@@ -73,6 +73,12 @@
     margin: 0 !important;
 }
 
+.small { font-size: 0.85em; }
+
+/* Lock the scroll position by adding this class to the `<html>` element. */
+.lock-scroll { overflow: hidden !important; }
+
+
 /* A container with a bright background used to wrap content when a dark color is used for the main background. */
 .lbb-bright-container {
     background: #fff;

--- a/labonneboite/web/static/css/_layout.css
+++ b/labonneboite/web/static/css/_layout.css
@@ -129,11 +129,13 @@ ul.lbb-header {
     font-size: 0.75rem;
     text-transform: uppercase;
     color: #5d5d5d;
+    border: none;
 }
 
 .lbb-header-btn:active,
 .lbb-header-btn:hover {
     background-color: #cbcbcb;
+    cursor: pointer;
 }
 
 .lbb-header-btn img {
@@ -187,7 +189,6 @@ ul.lbb-header {
 .lbb-footer .lbb-sponsor-text {
     grid-area: footer-text;
     margin-top: 0;
-    text-align: justify;
 }
 .lbb-footer center {
     grid-area: footer-update;

--- a/labonneboite/web/static/css/home.css
+++ b/labonneboite/web/static/css/home.css
@@ -10,6 +10,7 @@
 
     .lbb-home-explanation {
         margin: 40px 0 80px 0;
+        font-size: 0.85em;
     }
 
 }

--- a/labonneboite/web/static/css/modal.css
+++ b/labonneboite/web/static/css/modal.css
@@ -67,5 +67,4 @@
 .modal-content-inner {
     display: table-cell;
     vertical-align: middle;
-    text-align: justify;
 }

--- a/labonneboite/web/static/css/rgpd_banner.css
+++ b/labonneboite/web/static/css/rgpd_banner.css
@@ -25,9 +25,13 @@
     margin-top: 0;  /* Cancel default spacing across block-level elements inside. */
 }
 
-.rgpd-banner a:link,
-.rgpd-banner a:visited,
-.rgpd-banner a:active,
-.rgpd-banner a:hover {
+.rgpd-banner button {
+    font-size: 1em;
+    text-decoration: underline;
+    border: none;
+    background-color: transparent;
     color: #fff;
+}
+.rgpd-banner button:hover {
+    cursor: pointer;
 }

--- a/labonneboite/web/static/js/dropdowns.js
+++ b/labonneboite/web/static/js/dropdowns.js
@@ -11,7 +11,7 @@
       $.deactivateAllDropdowns();
     });
 
-    $('.lbb-dropdown-wrapper > a').toggleDropdown();
+    $('.lbb-dropdown-wrapper > .lbb-header-btn').toggleDropdown();
 
   });
 
@@ -34,6 +34,7 @@
       $.deactivateAllDropdowns();
       // Activate the current dropdown.
       $wrapper.addClass('active');
+      $('.lbb-dropdown-wrapper > .lbb-header-btn').attr('aria-expanded', 'true');
       $dropdown.css('display', 'block');
 
     });
@@ -42,6 +43,7 @@
 
   jQuery.deactivateAllDropdowns = function () {
     $('.lbb-dropdown-wrapper').removeClass('active');
+    $('.lbb-dropdown-wrapper > .lbb-header-btn').attr('aria-expanded', 'false');
     $('.lbb-dropdown').css('display', 'none');
   };
 

--- a/labonneboite/web/static/js/homepage-form.js
+++ b/labonneboite/web/static/js/homepage-form.js
@@ -59,10 +59,6 @@
       });
     };
 
-    if (!inputJob.val()) {
-      inputJob.focus();
-    }
-
     // Configure autocompletes.
     inputJob.autocomplete({
       delay: 200,

--- a/labonneboite/web/static/js/modal.js
+++ b/labonneboite/web/static/js/modal.js
@@ -1,16 +1,62 @@
 /* jshint esversion: 6 */
 
+window.$openingButton = undefined;
+window.$focusables = undefined;
+window.focusableIndex = 0;
+
+
+var FOCUSABLE_ELEMENTS = 'a[href], area[href], input:not([disabled]):not([type="hidden"]):not([aria-hidden]), select:not([disabled]):not([aria-hidden]), textarea:not([disabled]):not([aria-hidden]), button:not([disabled]):not([aria-hidden]), iframe, object, embed, [contenteditable], [tabindex]:not([tabindex^="-"])';
+
 function closeModals() {
     if (jQuery(".modal").not(".modal-closed")) {
         ga('send', 'event', 'Modal', 'close');
         jQuery(".modal").addClass("modal-closed");
+        jQuery(".modal").attr("aria-hidden", "true");
         jQuery(".modal-overlay").addClass("modal-closed");
     }
+
+    // When closing the modal, we need to return to the opening button
+    if(window.$openingButton) {
+        window.$openingButton.focus()
+        window.$openingButton = undefined;
+    }
+
+    // Clear focusable elements data
+    window.$focusables = undefined;
+    window.focusableIndex = 0;
+
+    // Make the scroll back
+    jQuery('html').removeClass('lock-scroll');
+}
+
+function focusToNext() {
+    window.focusableIndex = window.focusableIndex + 1;
+    if (window.focusableIndex >= window.$focusables.length) window.focusableIndex = 0;
+    window.$focusables.get(window.focusableIndex).focus();
+}
+function focusToPrevious() {
+    window.focusableIndex = window.focusableIndex - 1;
+    if (window.focusableIndex < 0) window.focusableIndex = window.$focusables.length - 1;
+    window.$focusables.get(window.focusableIndex).focus();
 }
 
 function showModal(selector) {
-    jQuery(selector).removeClass("modal-closed");
+    var $modal = jQuery(selector);
+    $modal.removeClass("modal-closed");
+    $modal.attr("aria-hidden", "false");
+
     jQuery(".modal-overlay").removeClass("modal-closed");
+
+    // Save opening button for later
+    window.$openingButton = jQuery(document.activeElement);
+
+    // Remove scroll
+    jQuery('html').addClass('lock-scroll');
+
+    // Save all focusable elements in modal + init counter + First focus
+    window.$focusables = $modal.find(FOCUSABLE_ELEMENTS);
+    window.focusableIndex = 0;
+    window.$focusables.get(window.focusableIndex).focus();
 
     // Click on close button
     jQuery(".modal-close-button").one("click", function() {
@@ -25,7 +71,20 @@ function showModal(selector) {
 
 // Capture escape key
 jQuery("body").keydown(function(evt) {
-    if (evt.which == 27) {
-        closeModals();
+    var TAB_KEY = 9;
+    var ECHAP_KEY = 27;
+
+    if (evt.which == ECHAP_KEY) closeModals();
+
+    if (jQuery(".modal").not(".modal-closed").length) {
+        // Shift+Tab : focus to previous element
+        if (evt.shiftKey && evt.keyCode == TAB_KEY) {
+            evt.preventDefault();
+            focusToPrevious();
+        // Tab : focus to next element
+        } else if (evt.keyCode == TAB_KEY) {
+            evt.preventDefault();
+            focusToNext();
+        }
     }
 });

--- a/labonneboite/web/static/js/transparent-sso.js
+++ b/labonneboite/web/static/js/transparent-sso.js
@@ -45,6 +45,8 @@
           var peamURL = window.location.origin + '/authorize/login/peam-openidconnect-no-prompt/?keep=1&next=' + encodeURIComponent(iframeUrl);
           var ifr = document.createElement("iframe");
           ifr.setAttribute("src", peamURL);
+          ifr.setAttribute('aria-hidden', 'true');
+          ifr.setAttribute('title', 'Dispositif technique (aucun contenu)');
           ifr.setAttribute("style", "display:none;");
           document.body.appendChild(ifr);
           localStorage.setItem(sso_storage_entry, now);

--- a/labonneboite/web/templates/base.html
+++ b/labonneboite/web/templates/base.html
@@ -17,23 +17,24 @@
 </head>
 
 <body>
+  <a class="escape-link" href="#main-anchor">Passer directement au contenu principal</a>
 
   <div class="rgpd-banner">
     <p>En poursuivant votre navigation sur ce site, vous acceptez nos conditions d'utilisation de vos données personnelles (RGPD).</p>
     <p>
-      <a href="#" class="rgpd-accept"><b>Accepter</b></a>
+      <button class="rgpd-accept"><b>Accepter</b></button>
       -
-      <a href="#" class="rgpd-info">En savoir plus</a>
+      <button class="rgpd-info" aria-haspopup="true" aria-controls="#modal-id">En savoir plus</button>
       -
-      <a href="#" class="rgpd-reject"><b>Refuser</b></a>
+      <button class="rgpd-reject"><b>Refuser</b></button>
     </p>
   </div>
 
-  <header class="lbb-header-wrapper">
+  <header role="banner" class="lbb-header-wrapper">
     <ul class="lbb-header">
       <li class="lbb-header-logo-lbb">
         <a href="/">
-          <img src="{{ url_for('static', filename='images/logo-lbb.svg') }}" alt="Logo La Bonne Boite">
+          <img src="{{ url_for('static', filename='images/logo-lbb.svg') }}" alt="Logo La Bonne Boite - Pôle Emploi">
         </a>
       </li>
 
@@ -48,7 +49,14 @@
       {# PRO ZONE #}
       {% if user_is_pro %}
         <li class="float-right lbb-header-entry">
-          <a class="lbb-header-btn" href="{{ url_for('user.pro_version') }}?next={{ request.url | urlencode }}">
+          <a
+            class="lbb-header-btn" href="{{ url_for('user.pro_version') }}?next={{ request.url | urlencode }}"
+            {% if pro_version_enabled %}
+              title="Désactiver la version pro"
+            {% else %}
+              title="Activer la version pro"
+            {% endif %}
+          >
             <span class="lbb-header-btn no-padding">
               {% if pro_version_enabled %}
                 <img class="no-margin" src="{{ url_for('static', filename='images/pro/pro-color.svg') }}" alt="Version PRO active" data-toggle="tooltip" data-placement="bottom" data-original-title="La version PRO affiche des indicateurs exclusifs (Junior, Senior et BOE [Bénéficiaire de l'Obligation d'Emploi]) non disponibles au public, uniquement visibles aux conseillers Pôle emploi et à une sélection d'acteurs.">
@@ -57,9 +65,9 @@
               {% endif %}
             </span>
             {% if pro_version_enabled %}
-              <p class="lbb-switch on">
+              <p class="lbb-switch on" aria-hidden="true">
             {% else %}
-              <p class="lbb-switch">
+              <p class="lbb-switch" aria-hidden="true">
             {% endif %}
               <span class="on">On</span>
               <span class="off">Off</span>
@@ -84,16 +92,19 @@
     {% endif %}
   {% endwith %}
 
-  <div id="content">{% block content %}{% endblock %}</div>
+  <main role="main" id="content">
+    <a id="main-anchor" tabindex="-1"></a>
+    {% block content %}{% endblock %}
+  </main>
 
-  <footer class="lbb-footer-wrapper">
+  <footer class="lbb-footer-wrapper" role="contentinfo">
     <div class="lbb-footer">
       <ul>
         <li>
           <a href="{{ url_for('root.lbb_help') }}" title="Conseils pour faire une candidature spontanée">Conseils</a>
         </li>
         <li>
-          <a href="{{ url_for('root.faq') }}" title="Questions fréquentes">F.A.Q</a>
+          <a href="{{ url_for('root.faq') }}" title="F.A.Q -Questions fréquentes">F.A.Q</a>
         </li>
         <li>
           <a href="https://www.emploi-store-dev.fr/portail-developpeur/detailapicatalogue/57909ba23b2b8d019ee6cc5f" title="Documentation de notre API pour développeurs">API</a>
@@ -102,10 +113,10 @@
           <a href="https://github.com/StartupsPoleEmploi/labonneboite" title="Consulter notre code source ouvert sur Github pour développeurs">Code source ouvert</a>
         </li>
         <li>
-          <a href="{{ url_for('root.cgu') }}" title="Conditions générales d'utilisation">C.G.U</a>
+          <a href="{{ url_for('root.cgu') }}" title="C.G.U - Conditions générales d'utilisation">C.G.U</a>
         </li>
         <li>
-          <a href="{{ url_for('root.press') }}" title="Contenu à destination de la presse">Espace Presse</a>
+          <a href="{{ url_for('root.press') }}" title="Espace presse - Contenu à destination de la presse">Espace Presse</a>
         </li>
         <li>
           <a href="#" class="rgpd-info" title="Politique de confidentialité et utilisation de vos données personnelles (R.G.P.D)">R.G.P.D</a>
@@ -122,11 +133,11 @@
         {% if pro_version_enabled %}
           <li>
             <a href="{{ url_for('root.kit') }}" title="Télécharger le kit de présentation de La Bonne Boite">Boîte à outils (fichier <abbr title="Portable Document Format">PDF</abbr>, 400 <abbr title="Kilo octets">ko</abbr>)</a>
-            <small class="badge badge-info">PRO</small>
+            <span class="badge badge-info small">PRO</span>
           </li>
           <li>
             <a href="{{ url_for('root.stats') }}" title="Consulter nos statistiques sur Google Analytics">Statistiques</a>
-            <small class="badge badge-info">PRO</small>
+            <span class="badge badge-info small">PRO</span>
           </li>
         {% endif %}
       </ul>
@@ -144,12 +155,12 @@
   </footer>
 
 
-  <div id="rgpd-modal" class="modal modal-closed">
+  <div id="rgpd-modal" class="modal modal-closed" aria-modal="true" aria-hidden="true" aria-labelledby="#rgpd-modal-title">
     <button class="modal-close-button"><img alt="Fermer la fenêtre" src="{{ url_for('static', filename='images/icons/times.svg') }}"></button>
     <div class="modal-content modal-content-inner">
-      <h2 class="text-center">
+      <h1 class="text-center" id="rgpd-modal-title">
         Politique de confidentialité et utilisation de vos données personnelles
-      </h2>
+      </h1>
 
       <p>
         Pour utiliser le service La Bonne Boite, vous devez accepter la Politique de confidentialité de La Bonne Boite.
@@ -193,8 +204,8 @@
     </div>
   </div>
 
-    <div class="modal-overlay modal-closed"></div>
-    <div id="tilkee-modal" class="modal modal-closed">
+  <div class="modal-overlay modal-closed"></div>
+    <div id="tilkee-modal" class="modal modal-closed" aria-modal="true" aria-hidden="true">
         <button class="modal-close-button"><img alt="Fermer la fenêtre" src="{{ url_for('static', filename='images/icons/times.svg') }}"></button>
         <div class="modal-content">
             <div class="modal-content-inner text-left text-bold" style="font-size: 140%;">
@@ -204,14 +215,14 @@
       </div>
   </div>
 
-  <div id="jepostule-not-authentified-modal" class="modal modal-closed">
+  <div id="jepostule-not-authentified-modal" class="modal modal-closed" aria-modal="true" aria-hidden="true" aria-labelledby="#je-postule-title">
     <button class="modal-close-button"><img alt="Fermer la fenêtre" src="{{ url_for('static', filename='images/icons/times.svg') }}"></button>
     <div class="modal-content">
       <div class="modal-content-inner text-center">
-        <p class="text-bold">Cette fonctionnalité est disponible uniquement aux utilisateurs connectés.</p>
+        <p id="je-postule-title" class="text-bold">Cette fonctionnalité est disponible uniquement aux utilisateurs connectés.</p>
         <p>
             <a class="logo-pe-connect rgpd-consent-required" href="{{ url_for('social.auth', backend='peam-openidconnect') }}?next={{ (next_url or request.url) | urlencode }}">
-              <img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Pôle emploi Connect">
+              <img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Se connecter avec Pôle emploi">
             </a>
           </p>
       </div>

--- a/labonneboite/web/templates/base_lba.html
+++ b/labonneboite/web/templates/base_lba.html
@@ -11,7 +11,9 @@
 </head>
 
 <body>
-  <header class="lbb-header-wrapper">
+  <a class="escape-link" href="#main-anchor">Passer directement au contenu principal</a>
+
+  <header role="banner" class="lbb-header-wrapper">
     <a href="{{ url_for('root.home') }}" title="Aller sur la Bonne Boite - Ouverture dans une nouvelle fenêtre" target="_blank">
       <img class="logo-lbb" src="{{ url_for('static', filename='images/logo-lbb.svg') }}" alt="Logo La Bonne Boite" width="74">
     </a>
@@ -32,7 +34,10 @@
     {% endif %}
   {% endwith %}
 
-  <div id="content">{% block content %}{% endblock %}</div>
+  <main role="main" id="content">
+    <a id="contenu" tabindex="-1"></a>
+    {% block content %}{% endblock %}
+  </main>
 
   {% assets "js_all" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {% assets "recruiter_form" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}

--- a/labonneboite/web/templates/contact_form/ask_recruiter_pe_connect.html
+++ b/labonneboite/web/templates/contact_form/ask_recruiter_pe_connect.html
@@ -18,11 +18,11 @@
         <p class="text-center">
             {% if use_lba_template %}
             <a class="logo-pe-connect rgpd-consent-required" title="Se connecter avec Pôle Emploi recruteur" href="{{ url_for('auth.peam_recruiter_connect', action_name=action_name, siret=siret, origin='labonnealternance' )}}">
-                <img src="/static/images/logo-pe-connect.svg" alt="Pôle emploi Connect">
+                <img src="/static/images/logo-pe-connect.svg" alt="Se connecter avec Pôle emploi recruteur">
             </a>
             {% else %}
             <a class="logo-pe-connect rgpd-consent-required" title="Se connecter avec Pôle Emploi recruteur" href="{{ url_for('auth.peam_recruiter_connect', action_name=action_name, siret=siret) }}">
-                <img src="/static/images/logo-pe-connect.svg" alt="Pôle emploi Connect">
+                <img src="/static/images/logo-pe-connect.svg" alt="Se connecter avec Pôle emploi recruteur">
             </a>
             {% endif %}
         </p>

--- a/labonneboite/web/templates/home.html
+++ b/labonneboite/web/templates/home.html
@@ -34,8 +34,8 @@
     </form>
 
     {% if not pro_version_enabled %}
-      <p class="lbb-home-explanation lbb-grey">
-        <small>*Grâce à un algorithme exclusif de Pôle emploi détectant les entreprises qui vont probablement embaucher ces 6 prochains mois.</small>
+      <p class="lbb-home-explanation lbb-grey small">
+        *Grâce à un algorithme exclusif de Pôle emploi détectant les entreprises qui vont probablement embaucher ces 6 prochains mois.
       </p>
     {% endif %}
 

--- a/labonneboite/web/templates/includes/office/content.html
+++ b/labonneboite/web/templates/includes/office/content.html
@@ -62,8 +62,8 @@
           <li>
             <a href="{{ company.kompass_url }}" target="_blank" onclick="trackOutboundLink('{{ company.kompass_url }}');">Kompass</a>
           </li>
-          <li>
-            <small>SIRET : {{ company.siret }}</small>
+          <li class="small">
+            SIRET : {{ company.siret }}
           </li>
         </ul>
 

--- a/labonneboite/web/templates/includes/office/header.html
+++ b/labonneboite/web/templates/includes/office/header.html
@@ -2,19 +2,19 @@
 
   <h3>
     <span>{{ company.name }}</span>
-    - <small>{{ company.city }}</small>
+    - <span class="small">{{ company.city }}</span>
     {% if pro_version_enabled %}
       {% if company.flag_junior %}
-        - <small class="badge badge-info" data-toggle="tooltip" title="Cette entreprise recrute une proportion élevée de juniors (moins de 26 ans) - indicateur exclusif version PRO">
-        Junior</small>
+        - <span class="small badge badge-info" data-toggle="tooltip" title="Cette entreprise recrute une proportion élevée de juniors (moins de 26 ans) - indicateur exclusif version PRO">
+        Junior</span>
       {% endif %}
       {% if company.flag_senior %}
-        - <small class="badge badge-info" data-toggle="tooltip" title="Cette entreprise recrute une proportion élevée de seniors (plus de 50 ans) - indicateur exclusif version PRO">
-        Senior</small>
+        - <span class="small badge badge-info" data-toggle="tooltip" title="Cette entreprise recrute une proportion élevée de seniors (plus de 50 ans) - indicateur exclusif version PRO">
+        Senior</span>
       {% endif %}
       {% if company.flag_handicap %}
-        - <small class="badge badge-info" data-toggle="tooltip" title="Cette entreprise recrute des BOE (Bénéficiaire de l'Obligation d'Emploi) - indicateur exclusif version PRO">
-        BOE</small>
+        - <span class="small badge badge-info" data-toggle="tooltip" title="Cette entreprise recrute des BOE (Bénéficiaire de l'Obligation d'Emploi) - indicateur exclusif version PRO">
+        BOE</span>
       {% endif %}
     {% endif %}
   </h3>

--- a/labonneboite/web/templates/includes/search_form.html
+++ b/labonneboite/web/templates/includes/search_form.html
@@ -21,7 +21,7 @@
   </div>
 
   <button class="btn" type="submit">
-    <img src="{{ url_for('static', filename='images/icons/magnifier-white.svg') }}" alt="Chercher">
+    <img src="{{ url_for('static', filename='images/icons/magnifier-white.svg') }}" alt="Lancer la recherche">
     <span class="spinner hidden"></span>
   </button>
 

--- a/labonneboite/web/templates/root/accessibility.html
+++ b/labonneboite/web/templates/root/accessibility.html
@@ -3,7 +3,7 @@
 {% block title %}Conditions Générales d'Utilisation{% endblock %}
 
 {% block content %}
-<main class="lbb-content">
+<div class="lbb-content">
     <div class="lbb-single-column-content">
         <h1>Accessibilité</h1>
 
@@ -32,7 +32,7 @@
         <p>
             Le site <a href="https://labonneboite.pole-emploi.fr">La Bonne Boite</a> est en cours d’optimisation afin de
             le rendre conforme au 
-            <a  href="http://references.modernisation.gouv.fr/referentiel/" target="_blank" title="Visiter la page dédiée au référentiel RGAA (Ouverture dans un nouvel onglet)">RGAA v3</a>.
+            <a  href="http://references.modernisation.gouv.fr/referentiel/" target="_blank" title="Visiter la page dédiée au référentiel RGAA (Ouverture dans une nouvelle fenêtre)">RGAA v3</a>.
             La déclaration de conformité sera publiée ultérieurement.
         </p>
 
@@ -76,5 +76,5 @@
 
     </div>
 
-</main>
+</div>
 {% endblock %}

--- a/labonneboite/web/templates/root/cgu.html
+++ b/labonneboite/web/templates/root/cgu.html
@@ -6,23 +6,23 @@
 <div class="lbb-content">
   <div class="lbb-single-column-content">
 
-    <h2>Conditions d'utilisation</h2>
+    <h1>Conditions d'utilisation</h1>
 
     <div class="text-center"><em>Dernière mise à jour le : 22/10/2018</em></div>
 
-    <h3>1. Informations légales</h3>
-    <h4>Editeur</h4>
+    <h2>1. Informations légales</h2>
+    <h3>Editeur</h3>
     <p>
       Pôle emploi<br>
       15 avenue du Docteur Gley<br>
       75987 Paris cedex 20<br>
       Tél. 01 40 30 60 00<br>
     </p>
-    <h4>Directeur de la publication</h4>
+    <h3>Directeur de la publication</h3>
     <p>
       Monsieur Jean Bassères, Directeur général.
     </p>
-    <h4>Hébergeur</h4>
+    <h3>Hébergeur</h3>
     <p>
       OVH<br>
       2 rue Kellermann<br>
@@ -30,10 +30,10 @@
       Tél. 09 72 10 10 07<br>
     </p>
 
-    <h3>2. Objet du site internet <a href="//{{ host }}">{{ host }}</a></h3>
+    <h2>2. Objet du site internet <a href="//{{ host }}">{{ host }}</a></h2>
     <p>Le site internet <a href="//{{ host }}">{{ host }}</a> a pour objet de faciliter les démarches de candidatures spontanées de l’utilisateur en l’aidant à identifier des entreprises ou organismes ayant un potentiel d’embauche dans un secteur d’emploi et un secteur géographique donnés.</p>
 
-    <h3>3. Données collectées</h3>
+    <h2>3. Données collectées</h2>
     <p>Les seules données collectées, pour permettre le fonctionnement du service, sont le type d’emploi recherché et le périmètre géographique souhaité. Ces données sont collectées et traitées par Pôle emploi pour la seule finalité définie à l’article 2 et ne sont pas conservées.</p>
     <p>Toutefois, l’utilisateur est informé que conformément aux articles 39 et suivants de la loi n°78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés, il dispose d’un droit d’accès aux informations le concernant, en s’adressant :</p>
     <ul>
@@ -42,7 +42,7 @@
     </ul>
     <p>Il est possible pour les entreprises voulant ne plus apparaître dans les résultats de La Bonne Boite, ou voulant modifier leurs coordonnées ou tout renseignement qui leur paraîtrait inexact, de <a href="{{ url_for('contact_form.change_info') }}">faire une demande de modification</a>.</p>
 
-    <h3>4. Cookies</h3>
+    <h2>4. Cookies</h2>
     <p>Pôle emploi utilise des cookies permettant d’enregistrer des informations relatives à la navigation de l’utilisateur de manière anonyme et dans un but d’analyses statistiques. Les cookies générés ont une durée de conservation limitée à 12 mois. Ces cookies sont émis par les sociétés Google et Hotjar. L’utilisateur peut s’opposer à l'enregistrement de cookies sur son ordinateur :
     <ul>
       <li>en configurant son poste informatique de la manière suivante :
@@ -78,13 +78,13 @@
       </li>
     </ul>
 
-    <h3>5. Fonctionnement du service</h3>
+    <h2>5. Fonctionnement du service</h2>
     <p>Le service proposé sur le site <a href="//{{ host }}">{{ host }}</a> permet à l’utilisateur de rechercher dans les bases de données de Pôle emploi, des entreprises susceptibles de recruter des profils similaires au sien en fonction des critères qu’il a défini.</p>
 
-    <h3>6. Responsabilités</h3>
+    <h2>6. Responsabilités</h2>
     <ol>
       <li>
-        <h4>Résultats de recherche</h4>
+        <h3>Résultats de recherche</h3>
         <p>Pôle emploi décline toute responsabilité, envers l’utilisateur et/ou envers les entreprises ou organismes, concernant notamment :</p>
         <ul>
           <li>l’absence de résultat au regard des critères définis par l’utilisateur</li>
@@ -97,13 +97,13 @@
       </li>
     </ol>
 
-    <h3>7. Obligations de l'utilisateur</h3>
+    <h2>7. Obligations de l'utilisateur</h2>
     <p>L’utilisateur du site reconnaît avoir pris connaissance et accepter les présentes conditions d’utilisation avant toute utilisation du site.</p>
     <p>L’utilisation du site internet <a href="//{{ host }}">{{ host }}</a> est soumise au respect par  l’utilisateur de : la législation française, les présentes conditions d’utilisation, les conditions d’utilisation de l’Emploi store disponibles à l’adresse suivante : <a href="http://www.emploi-store.fr/portail/conditionsgeneralesutilisation">http://www.emploi-store.fr/portail/conditionsgeneralesutilisation</a>.
     </p>
     <p>Les présentes conditions d’utilisation peuvent être modifiées à tout moment ; la date de mise à jour est mentionnée. Ces modifications sont opposables à l’utilisateur dès leur mise en ligne sur le site internet <a href="//{{ host }}">{{ host }}</a>. L’utilisateur est donc invité à consulter régulièrement la dernière version mise à jour.</p>
 
-    <h3>8. Propriété intellectuelle</h3>
+    <h2>8. Propriété intellectuelle</h2>
     <p>Le site web <a href="//{{ host }}">{{ host }}</a> est protégé au titre des dispositions relatives au droit d’auteur défini aux articles L.111-1 et suivants du code de la propriété intellectuelle et au titre des dispositions relatives aux bases de données définies aux articles L.341-1 et suivants du même code. Pôle emploi est titulaire de l’ensemble des droits de propriété intellectuelle sur les éléments composant le site et la base de données relative aux offres d’emploi.</p>
     <p>Sans préjudice des dispositions prévues à l’article L.122-5 du code de la propriété intellectuelle, toute représentation, reproduction ou diffusion, intégrale ou partielle du site, sur quelque support que ce soit, sans l'autorisation expresse et préalable de Pôle emploi constitue un acte de contrefaçon, sanctionné au titre des articles L.335-2 et L.335.3 du même code.</p>
     <p>Sans préjudice des dispositions prévues à l’article L.342-3 du code de la propriété intellectuelle, toute représentation, reproduction ou diffusion, intégrale ou partielle de la base de données, sur quelque support que ce soit, sans l'autorisation expresse et préalable de Pôle emploi est sanctionné au titre des articles L.343-1 et suivants du même code.</p>

--- a/labonneboite/web/templates/root/cookbook.html
+++ b/labonneboite/web/templates/root/cookbook.html
@@ -46,7 +46,7 @@
           </a>
           <div class="lbb-dropdown lbb-dropdown-right text-right">
             <p>
-              <a class="logo-pe-connect" href="{{ login_url() }}"><img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Pôle emploi Connect"></a><br>
+              <a class="logo-pe-connect" href="{{ login_url() }}"><img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Se connecter avec Pôle emploi"></a><br>
               <i>Connectez-vous à La Bonne Boite en utilisant des identifiants Pôle emploi. Vous n'avez pas de compte ? Créez-en un et profitez de tous les services dédiés à l'emploi de nos partenaires.</i>
             </p>
           </div>
@@ -80,7 +80,7 @@
           </a>
           <div class="lbb-dropdown lbb-dropdown-right text-right">
             <p>
-              <a class="logo-pe-connect" href="{{ login_url }}"><img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Pôle emploi Connect"></a><br>
+              <a class="logo-pe-connect" href="{{ login_url }}"><img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Se connecter avec Pôle emploi"></a><br>
               <i>Connectez-vous à La Bonne Boîte en utilisant des identifiants Pôle emploi. Vous n'avez pas de compte ? Créez-en un et profitez de tous les services dédiés à l'emploi de nos partenaires.</i>
             </p>
           </div>
@@ -188,7 +188,7 @@
                    placeholder="Autour de : (Paris, Bd Voltaire, 33000...)">
           </div>
           <button class="btn" type="submit">
-            <img src="{{ url_for('static', filename='images/icons/magnifier-white.svg') }}" alt="Chercher">
+            <img src="{{ url_for('static', filename='images/icons/magnifier-white.svg') }}" alt="Lancer la recherche">
           </button>
         </div>
         <ul class="form-errorlist">
@@ -1351,7 +1351,7 @@
                        placeholder="Autour de : (Paris, Bd Voltaire, 33000...)">
               </div>
               <button class="btn" type="submit">
-                <img src="{{ url_for('static', filename='images/icons/magnifier-white.svg') }}" alt="Chercher">
+                <img src="{{ url_for('static', filename='images/icons/magnifier-white.svg') }}" alt="Lancer la recherche">
               </button>
             </div>
             <div class="lbb-sidebar-toggle-wrapper">

--- a/labonneboite/web/templates/root/faq.html
+++ b/labonneboite/web/templates/root/faq.html
@@ -11,40 +11,39 @@
 <div class="lbb-content">
   <div class="lbb-single-column-content">
 
-    <h2>Questions fréquemment posées (FAQ)</h2>
-    
+    <h1>Questions fréquemment posées (FAQ)</h1>
 
-    <h3>Il manque des entreprises dans la liste.</h3>
+    <h2>Il manque des entreprises dans la liste.</h2>
     <p>La Bonne Boite est bien plus qu’un simple annuaire. La Bonne Boite effectue un ciblage spécifique des entreprises à fort potentiel d’embauche afin de vous faire gagner du temps dans la sélection des entreprises à démarcher. Toutes les entreprises ne sont donc pas indiquées.</p>
 
-    <h3>Il n’est pas précisé si les entreprises embauchent.</h3>
+    <h2>Il n’est pas précisé si les entreprises embauchent.</h2>
     <p>La Bonne Boite ne propose pas d’offres d’emploi. Nous ciblons spécifiquement les entreprises ayant un fort potentiel d’embauche et vous mettons à disposition une liste par métier. Vous devez utiliser cette liste dans le cadre de candidatures spontanées. En effet, 75 % des recrutements ne sont jamais diffusés.</p>
 
-    <h3>Pourquoi certains secteurs d’activité ne sont pas proposés ?</h3>
+    <h2>Pourquoi certains secteurs d’activité ne sont pas proposés ?</h2>
     <p>La Bonne Boite vous indique uniquement les entreprises à fort potentiel d’embauche en fonction du métier sélectionné. Le tri par secteurs d’activité est donc uniquement possible sur les secteurs d’activité de ces entreprises. La recherche par secteur d’activité n’est actuellement pas disponible.</p>
 
-    <h3>La distance indiquée est erronée.</h3>
+    <h2>La distance indiquée est erronée.</h2>
     <p>Les distances indiquées sont les distances à vol d’oiseau. Si vous constatez tout de même une erreur, merci de nous contacter par l’intermédiaire du formulaire “Donner votre avis” (à droite de l’écran).</p>
 
-    <h3>J’ai indiqué un métier précis, et les entreprises présentées ne correspondent pas à mes attentes.</h3>
+    <h2>J’ai indiqué un métier précis, et les entreprises présentées ne correspondent pas à mes attentes.</h2>
     <p>La Bonne Boite vous indique uniquement les entreprises à fort potentiel d’embauche en fonction du métier sélectionné. Il est donc possible que certains secteurs d’activité vous surprennent, ou que vous pensiez qu’il en manque. Si malgré tout vous pensez que des entreprises différentes devraient figurer pour votre recherche vous pouvez nous contacter par l’intermédiaire du formulaire “donner votre avis”.</p>
 
-    <h3>Le métier que je recherche n’est pas présent.</h3>
+    <h2>Le métier que je recherche n’est pas présent.</h2>
     <p>La Bonne Boite utilise le Répertoire Opérationnel des Métiers et des Emplois (ROME). Seuls les métiers et appellations présents dans ce répertoire sont disponibles.</p>
 
-    <h3>Il n’y a pas de précisions sur les profils recherchés.</h3>
+    <h2>Il n’y a pas de précisions sur les profils recherchés.</h2>
     <p>La Bonne Boite vous indique uniquement les entreprises à fort potentiel d’embauche. Il n’y a donc pas d’offres d’emploi. Il s’agit d’entreprises ciblées auprès desquelles vous pouvez envoyer des candidatures spontanées.</p>
 
-    <h3>Il manque des coordonnées : courriel, téléphone…</h3>
+    <h2>Il manque des coordonnées : courriel, téléphone…</h2>
     <p>La Bonne Boite vous indique uniquement les coordonnées portées à notre connaissance par les entreprises.</p>
 
-    <h3>Les coordonnées des entreprises sont erronées.</h3>
+    <h2>Les coordonnées des entreprises sont erronées.</h2>
     <p>La Bonne Boite vous indique uniquement les coordonnées portées à notre connaissance par les entreprises. La mise à jour des coordonnées est également réalisée par les entreprises qui peuvent omettre de nous prévenir.</p>
 
-    <h3>Comment rechercher sur un département entier ?</h3>
+    <h2>Comment rechercher sur un département entier ?</h2>
     <p>Cette fonctionnalité n’est actuellement pas disponible.</p>
 
-    <h3>J’ai une suggestion d’amélioration de La Bonne Boite, comment puis-je vous la transmettre ?</h3>
+    <h2>J’ai une suggestion d’amélioration de La Bonne Boite, comment puis-je vous la transmettre ?</h2>
     <p>Laissez un message en cliquant sur "Donner votre avis" à droite de l’écran.</p>
 
   </div>

--- a/labonneboite/web/templates/root/help.html
+++ b/labonneboite/web/templates/root/help.html
@@ -11,11 +11,11 @@
 <div class="lbb-content">
   <div class="lbb-single-column-content">
 
-    <h2>Comment faire une candidature spontanée ?</h2>
+    <h1>Comment faire une candidature spontanée ?</h1>
 
     <p>Effectuer une candidature spontanée est un acte de recherche d’emploi. Il s’agit de proposer votre candidature à une entreprise que vous avez choisie parmi d’autres. Ce choix est réfléchi. Cela ne correspond pas à un envoi massif de CV identiques à une liste d’entreprises. Pour que votre candidature spontanée soit réussie, il va falloir la personnaliser. Contrairement à la réponse à une offre d’emploi, vous n’êtes pas contraint à répondre rapidement. Vous devez prendre soin de respecter plusieurs étapes pour garantir votre succès.</p>
 
-    <h3>1. Cibler les entreprises</h3>
+    <h2>1. Cibler les entreprises</h2>
     <p>Ce travail préalable est nécessaire pour limiter son choix d’entreprises à contacter. Le ciblage est déterminé par :</p>
     <ul>
       <li>Votre projet professionnel : quel(s) métiers pouvez-vous exercer, quelle(s) conditions de travail acceptez-vous, …</li>
@@ -23,63 +23,62 @@
     </ul>
     <p>A l’issue de votre ciblage, vous devez avoir une liste d’entreprises répondant à vos critères : elles emploient du personnel ayant votre profil et se  situent dans votre secteur géographique. Si vous souhaitez de l’aide pour réaliser cette étape et répondre aux différentes questions, vous pouvez participer à trois ateliers Pôle emploi :</p>
     <ul>
-      <li><a target="_blank" href="https://www.pole-emploi.fr/candidat/identifier-mes-atouts-et-valoriser-mon-projet-professionnel-@/article.jspz?id=281997">Identifier ses atouts et valoriser son projet professionnel</a></li>
-      <li><a target="_blank" href="https://www.pole-emploi.fr/candidat/atelier-methode-de-recherche-et-d-analyse-d-informations-@/article.jspz?id=377842">Méthode de recherche et d'analyse d'informations</a></li>
-      <li><a target="_blank" href="http://www.pole-emploi.fr/candidat/cibler-ma-recherche-d-emploi-@/article.jspz?id=282017">Cibler les entreprises</a>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="https://www.pole-emploi.fr/candidat/identifier-mes-atouts-et-valoriser-mon-projet-professionnel-@/article.jspz?id=281997">Identifier ses atouts et valoriser son projet professionnel</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="https://www.pole-emploi.fr/candidat/atelier-methode-de-recherche-et-d-analyse-d-informations-@/article.jspz?id=377842">Méthode de recherche et d'analyse d'informations</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.pole-emploi.fr/candidat/cibler-ma-recherche-d-emploi-@/article.jspz?id=282017">Cibler les entreprises</a>
       </li>
     </ul>
-    <p>Vous pouvez également suivre des MOOCS, sérious game, e-learning,…disponible sur l’Emploi Store  (<a target="_blank" href="http://www.emploi-store.fr/portail/centredinteret/choisirunmetier">Choisir un métier</a>) :</p>
+    <p>Vous pouvez également suivre des MOOCS, sérious game, e-learning,…disponible sur l’Emploi Store  (<a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/centredinteret/choisirunmetier">Choisir un métier</a>) :</p>
     <ul>
-      <li><a target="_blank" href="http://www.emploi-store.fr/portail/services/construireSonProjetProfessionnel">Construire son projet projet professionnel</a></li>
-      <li><a target="_blank" href="http://www.emploi-store.fr/portail/services/aventureMetier">Aventure métier</a></li>
-      <li><a target="_blank" href="http://www.emploi-store.fr/portail/services/blogDesMetiers">Blog des métiers</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/services/construireSonProjetProfessionnel">Construire son projet projet professionnel</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/services/aventureMetier">Aventure métier</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/services/blogDesMetiers">Blog des métiers</a></li>
     </ul>
 
-    <h3>2. La personnalisation</h3>
+    <h2>2. La personnalisation</h2>
     <p>Première chose à faire : renseignez-vous sur l’entreprise. Pour chaque entreprise sélectionnée vous devez effectuer des recherches : a-t-elle un site Internet, est-t-elle présente sur les réseaux sociaux, dépose-t-elle des offres d’emploi, fait-elle parler d’elle sur Internet, dans la presse,… Prendre le temps d’effectuer ces recherches vous permet de mieux la connaître et de découvrir des contacts privilégiés (Directeur, responsable de recrutement, commercial,…). Cette étape vous permet également de préparer votre lettre de motivation et votre entretien pour donner l’impression que vous n’avez pas choisi cette entreprise par hasard. Si vous souhaitez de l’aide pour réaliser cette étape et répondre aux différentes questions, vous pouvez participer à deux ateliers Pôle emploi :</p>
     <ul>
-      <li><a target="_blank" href="http://www.pole-emploi.fr/candidat/cibler-ma-recherche-d-emploi-@/article.jspz?id=282017">Cibler les entreprises</a></li>
-      <li><a target="_blank" href="http://www.pole-emploi.fr/candidat/candidater-sans-offre-d-emploi-et-developper-mes-reseaux-notamment-les-reseaux-sociaux-@/article.jspz?id=282118">Préparer une candidature spontanée</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.pole-emploi.fr/candidat/cibler-ma-recherche-d-emploi-@/article.jspz?id=282017">Cibler les entreprises</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.pole-emploi.fr/candidat/candidater-sans-offre-d-emploi-et-developper-mes-reseaux-notamment-les-reseaux-sociaux-@/article.jspz?id=282118">Préparer une candidature spontanée</a></li>
     </ul>
-    <p>Vous pouvez également suivre des MOOCS, sérious game, e-learning,…disponible sur l’Emploi Store (<a target="_blank" href="http://www.emploi-store.fr/portail/centredinteret/preparersacandidature">Préparer sa candidature</a>) :</p>
+    <p>Vous pouvez également suivre des MOOCS, sérious game, e-learning,…disponible sur l’Emploi Store (<a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/centredinteret/preparersacandidature">Préparer sa candidature</a>) :</p>
     <ul>
-      <li><a target="_blank" href="http://www.emploi-store.fr/portail/services/reussirCvEtLettreDeMotivation">Réussir CV et Lettre de Motivation</a></li>
-      <li><a target="_blank" href="http://www.emploi-store.fr/portail/services/lettreDeMotivationEnUnClic">Lettre de motivation en un clic</a></li>
-      <li><a target="_blank" href="http://www.emploi-store.fr/portail/services/glassdoor">Glassdoor</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/services/reussirCvEtLettreDeMotivation">Réussir CV et Lettre de Motivation</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/services/lettreDeMotivationEnUnClic">Lettre de motivation en un clic</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" title="Consulter le site de Glassdoor" href="http://www.emploi-store.fr/portail/services/glassdoor">Glassdoor</a></li>
     </ul>
 
-    <h3>3. Déterminer la méthode de candidature spontanée adaptée</h3>
+    <h2>3. Déterminer la méthode de candidature spontanée adaptée</h2>
     <p>En fonction des secteurs d’activité, voire même d’une entreprise à l’autre, le mode de contact peut varier. Dans les secteurs du commerce, de la vente, de l’hôtellerie restauration, la présentation directe est appréciée : en prenant soin d’éviter les heures de fortes affluences, vous vous présentez directement à l’accueil de l’entreprise pour présenter votre candidature.  Dans l’industrie il est fréquent que des procédures spécifiques incluant un dossier de candidature existent. L’agent de sécurité présent au portail de l’entreprise saura vous renseigner sur ces pratiques. Pour les autres secteurs, l’envoi de votre candidature se fait de façon traditionnelle, par voie postale ou naturellement par courriel.</p>
-    <p>Vous pouvez suivre des MOOCS, sérious game, e-learning,…disponible sur l’Emploi Store  (<a target="_blank" href="http://www.emploi-store.fr/portail/centredinteret/preparersacandidature">Préparer sa candidature</a>) :</p>
+    <p>Vous pouvez suivre des MOOCS, sérious game, e-learning,…disponible sur l’Emploi Store  (<a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/centredinteret/preparersacandidature">Préparer sa candidature</a>) :</p>
     <ul>
-      <li><a target="_blank" href="http://www.emploi-store.fr/portail/services/organiserSaRechercheEmploi">Organiser sa recherche d’emploi</a></li>
-      <li><a target="_blank" href="http://www.emploi-store.fr/portail/services/bABaDeLaRechercheDEmploi">B.A.-BA de la recherche d’emploi</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/services/organiserSaRechercheEmploi">Organiser sa recherche d’emploi</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/services/bABaDeLaRechercheDEmploi">B.A.-BA de la recherche d’emploi</a></li>
     </ul>
 
-    <h3>4. Savoir à qui s'adresser</h3>
+    <h2>4. Savoir à qui s'adresser</h2>
     <p>Fréquemment, on adresse sa candidature au service des ressources humaines. Mais l’idéal est de l’adresser directement à la personne qui aura de l'influence sur votre éventuel recrutement, le directeur de la branche qui vous intéresse par exemple.  La personnalisation du destinataire vous permet  également de minimiser les risques de voir votre candidature traitée par le service des ressources humaines, qui n’est pas forcément au fait  des besoins de tous les services, ou qui ne peut saisir l’opportunité de recruter vos compétences.</p>
 
-    <h3>5. Personnalisez votre CV</h3>
-    <p>Un CV est plus que le reflet de votre parcours professionnel. Il doit permettre à son lecteur d’identifier vos compétences et de l’inciter à vous recevoir en entretien.  Aussi, en fonction de ce que vous aurez appris sur l’entreprise, vous déterminerez les compétences à mettre en avant. Si vous souhaitez de l’aide pour réaliser cette étape et répondre aux différentes questions, vous pouvez participer à l’atelier Pôle emploi <a target="_blank" href="https://www.pole-emploi.fr/candidat/outiller-ma-candidature-@/article.jspz?id=282097">Outiller ma candidaturev</a></p>
+    <h2>5. Personnalisez votre CV</h2>
+    <p>Un CV est plus que le reflet de votre parcours professionnel. Il doit permettre à son lecteur d’identifier vos compétences et de l’inciter à vous recevoir en entretien.  Aussi, en fonction de ce que vous aurez appris sur l’entreprise, vous déterminerez les compétences à mettre en avant. Si vous souhaitez de l’aide pour réaliser cette étape et répondre aux différentes questions, vous pouvez participer à l’atelier Pôle emploi <a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="https://www.pole-emploi.fr/candidat/outiller-ma-candidature-@/article.jspz?id=282097">Outiller ma candidaturev</a></p>
     <p>Vous pouvez suivre des MOOCS, sérious game, e-learning,…disponible sur l’Emploi Store :</p>
     <ul>
-      <li><a target="_blank" href="https://www.emploi-store.fr/portail/services/cvDoyoubuzzLeCvPdfWebEtMobile
-">DoYouBuzz</a></li>
-      <li><a target="_blank" href="http://www.emploi-store.fr/portail/services/cvPoleEmploi">CV Pôle emploi</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="https://www.emploi-store.fr/portail/services/cvDoyoubuzzLeCvPdfWebEtMobile">DoYouBuzz</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/services/cvPoleEmploi">CV Pôle emploi</a></li>
     </ul>
 
-    <h3>6. Réalisez votre lettre de motivation</h3>
+    <h2>6. Réalisez votre lettre de motivation</h2>
     <p>Faites court, précis et direct. Plus de 20 lignes effrayeront le recruteur. De plus, cela prouve que vous avez l’esprit de synthèse ! Dans votre texte, parlez de vous (ce que vous avez fait), de l’entreprise (pourquoi elle vous intéresse) et de vous deux (ce que vous pourriez vous apporter mutuellement).</p>
     <p>Vous pouvez également suivre des MOOCS, sérious game, e-learning,…disponible sur l’Emploi Store :</p>
     <ul>
-      <li><a target="_blank" href="http://www.emploi-store.fr/portail/services/reussirCvEtLettreDeMotivation">Réussir CV et Lettre de Motivation</a></li>
-      <li><a target="_blank" href="http://www.emploi-store.fr/portail/services/lettreDeMotivationEnUnClic">Lettre de motivation en un clic</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/services/reussirCvEtLettreDeMotivation">Réussir CV et Lettre de Motivation</a></li>
+      <li><a target="_blank" title="Ouverture dans une nouvelle fenêtre" href="http://www.emploi-store.fr/portail/services/lettreDeMotivationEnUnClic">Lettre de motivation en un clic</a></li>
     </ul>
 
-    <h3>7. Soignez la chute</h3>
+    <h2>7. Soignez la chute</h2>
     <p>L'entretien d'embauche n'est pas l'objectif ultime : le but de cette candidature spontanée est d’obtenir une prise de contact. Dans votre lettre, restez le plus ouvert possible quant à votre éventuel futur rôle dans le groupe ( « Je suis ouvert à tous types de collaboration ») et suggérez de rencontrer votre interlocuteur pour « échanger ». Si aucun poste n'est ouvert dans l'entreprise, vous pouvez au moins espérer que le recruteur se rappellera de vous pour une future opportunité.</p>
 
-    <h3>8. Relancez</h3>
+    <h2>8. Relancez</h2>
     <p>Comme lors d’une candidature classique, n’hésitez pas à relancer le recruteur en question. Certains recruteurs vont même attendre une relance pour s’intéresser à une candidature spontanée. Ne soyez pas trop oppressant, mais après huit jours sans réponse, vous pouvez raisonnablement décrocher votre téléphone…</p>
 
   </div>

--- a/labonneboite/web/templates/search/results_content.html
+++ b/labonneboite/web/templates/search/results_content.html
@@ -54,7 +54,7 @@
               <div class="lbb-sidebar-item">
                 <p>
                   {{ form.p.label }}
-                  <small class="badge badge-info" data-toggle="tooltip" data-placement="top" title="Entreprises recrutant une proportion élevée de juniors (- de 26 ans)
+                  <span class="badge badge-info small" data-toggle="tooltip" data-placement="top" title="Entreprises recrutant une proportion élevée de juniors (- de 26 ans)
                   / seniors (+ de 50 ans)
                   / BOE (Bénéficiaire de l'Obligation d'Emploi)
                   - indicateurs exclusifs version PRO">PRO</small>

--- a/labonneboite/web/templates/tilkee/login.html
+++ b/labonneboite/web/templates/tilkee/login.html
@@ -1,6 +1,6 @@
 <div class="modal-content-inner text-center">
     <a class="logo-pe-connect" href="{{ login_url }}">
-        <img class="tilkee-pe-connect" src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Pôle emploi Connect">
+        <img class="tilkee-pe-connect" src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Se connecter avec Pôle emploi">
     </a><br>
     <p>Connectez-vous à la Bonne Boite en utilisant vos identifiants Pôle Emploi. Vous n'avez pas de compte ? Créez-en un et profitez de tous les services dédiés à l'emploi de nos partenaires.</p>
 </div>

--- a/labonneboite/web/templates/user/favorites_list.html
+++ b/labonneboite/web/templates/user/favorites_list.html
@@ -54,8 +54,9 @@
       {% include "includes/pagination.html" %}
 
       <div class="alert alert-warning">
-        <p>
-          <small>Le potentiel d'embauche est actualisé chaque mois, des entreprises voyant leur potentiel d'embauche baisser peuvent disparaître de vos favoris. Pour les sauvegarder définitivement, nous vous conseillons de les importer dans MEMO.<br><a href="https://memo.pole-emploi.fr">MEMO</a> est un service de Pôle emploi vous permettant de gérer vos démarches de recherche d'emploi.</small>
+        <p class="small">
+          Le potentiel d'embauche est actualisé chaque mois, des entreprises voyant leur potentiel d'embauche baisser peuvent disparaître de vos favoris. Pour les sauvegarder définitivement, nous vous conseillons de les importer dans MEMO.<br>
+          <a href="https://memo.pole-emploi.fr">MEMO</a> est un service de Pôle emploi vous permettant de gérer vos démarches de recherche d'emploi.</small>
         </p>
       </div>
 

--- a/labonneboite/web/templates/user/header.html
+++ b/labonneboite/web/templates/user/header.html
@@ -1,23 +1,23 @@
 {% if not user.is_authenticated %}
 <div class="lbb-dropdown-wrapper lbb-header-btn-wrapper">
-  <a href="#" class="lbb-header-btn">
+  <button class="lbb-header-btn" aria-expanded="false" aria-controls="menu-content">
     <img src="{{ url_for('static', filename='images/user.svg') }}" alt="">
     <span>Connexion</span>
-  </a>
-  <div class="lbb-dropdown lbb-dropdown-right text-right">
+  </button>
+  <div id="menu-content" class="lbb-dropdown lbb-dropdown-right text-right">
     <p>
-    <a class="logo-pe-connect rgpd-consent-required" href="{{ login_url(next_url=next_url) }}"><img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Pôle emploi Connect"></a><br>
+    <a class="logo-pe-connect rgpd-consent-required" href="{{ login_url(next_url=next_url) }}"><img src="{{ url_for('static', filename='images/logo-pe-connect.svg') }}" alt="Se connecter avec Pôle emploi"></a><br>
       <i>Connectez-vous à La Bonne Boite en utilisant des identifiants Pôle emploi. Vous n'avez pas de compte ? Créez-en un et profitez de tous les services dédiés à l'emploi de nos partenaires.</i>
     </p>
   </div>
 </div>
 {% else %}
 <div class="lbb-dropdown-wrapper lbb-header-btn-wrapper">
-  <a href="#" class="lbb-header-btn">
+  <button class="lbb-header-btn" aria-expanded="false" aria-controls="menu-content">
     <img src="{{ url_for('static', filename='images/user-color.svg') }}" alt="">
-    <span>Mon compte</span>
-  </a>
-  <div class="lbb-dropdown lbb-dropdown-right text-right">
+    <span>Menu</span>
+  </button>
+  <div id="menu-content" class="lbb-dropdown lbb-dropdown-right text-right" role="navigation">
     <p>
       <b>{{ user.first_name | title }} {{ user.last_name }}</b>
     </p>
@@ -37,7 +37,7 @@
     <hr>
     {% if pro_version_enabled %}
       <p>
-        <small class="badge badge-info">Version PRO</small>
+        <span class="badge badge-info small">Version PRO</small>
       </p>
       <ul>
         <li>


### PR DESCRIPTION
**Home page (et blocs communs)** :
- Pas de texte justifié
- Utilisation de bouton à la place de liens (si nécessaire) 
- Ajout d'`aria-expanded` sur les dropdowns (indique l'état 'ouvert/fermé' de l'élément - utilisé par un lecteur d'écran)
- Retrait de l'autofocus sur le champ de formulaire métier (qui pertuberait les utilisateurs dans le cadre de leur navigation)
- iframe SSO => caché aux lecteurs d'écran + title indiquant qu'il s'agit d'un dispositif technique
- Meilleur texte d'aide pour PE Connect
- Suppression des balises `<small>` (utiliser des balises HTML pour son design est mal :) )
- Amélioration des `title` dans les liens du footer
- Ajout des `role` et de la balise `main` pour identifier les principales zones de la page
- Liens d'évitements
- Modales accessibles
- Placeholder mieux contrastés

**Pages : accessibilité / CGU / FAQ / Conseils** :
- Corrections de la hiérarchie de titres
- Indication d'ouverture dans une nouvelle fenêtre pour les liens nécessitants