### PR TITLE
Disallow PEAM url

### DIFF
--- a/labonneboite/web/static/robots.txt
+++ b/labonneboite/web/static/robots.txt
@@ -2,3 +2,6 @@ User-agent: *
 # Disabled to facilitate crawling, this parameter shouldn't be necessary.
 #Crawl-delay: 2 # sets a 2 second time-out
 Disallow: /*/download
+
+# We don't want Google to follow authorize URLs
+Disallow: /authorize/login/*


### PR DESCRIPTION
Goal : give more time to Google for crawling more intresting URLs