### PR TITLE
Add remote-pdb to debug in staging or in production safely.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -87,3 +87,4 @@ raven[flask]
 # Load testing.
 locustio
 pyzmq
+remote-pdb

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,6 +83,7 @@ pyvirtualdisplay==0.2.1
 pyzmq==16.0.2
 raven[flask]==6.9.0
 redis==3.2.1
+remote-pdb==1.3.0
 reportlab==3.5.21         # via xhtml2pdf
 requests-oauthlib==0.8.0  # via social-auth-core
 requests==2.21.0


### PR DESCRIPTION
Debugging in staging and in production is hard!

This PR lets us easily add a breakpoint in our code and debug using PDB.

## Usage

### Set a breaking point and target it
Add a breaking point in your code. :warning: This will of course block each incoming request, so make sure you know what you do.
Example:

```
# any/views.py

app.route('/armstrong')
def armstrong():
    if request.args('pdb'):
        from remote_pdb import RemotePdb
        RemotePdb('0.0.0.0', 4444).set_trace()
    return redirect(url_for('root.home'))
```

Then target your breaking point making a request to your route. Example: 

```
import requests
requests.get('http://wonderful.world/armstrong?pdb=true')
```

Nothing happens, it's normal! Time for step two.

### Getting the IP address if you're using Docker

Connect to the server via ssh.

Then get the container IP:

```
$ docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' container_name_or_id
# to get the container name, do a `docker ps`

176.3.33.3
```

Connect to your breaking point with telnet : 

```
$ telnet 176.3.33.3 4444
Trying 176.3.33.3...
Connected to 176.3.33.3.
Escape character is '^]'.
>  
```

### If you're not using Docker

Connect to the server via ssh. Then enter your breaking point with telnet : 

```
$ telnet 0.0.0.0 4444
Trying 0.0.0.0...
Connected to 0.0.0.0.
Escape character is '^]'.
>  
```

### Exiting pdb and telnet

To exit pdb, type 'c' in pdb and then `ctrl+]`.

Then type `quit` to exit telnet.

```
(Pdb) c
# Then type 'ctrl + ]'
^]
# And type 'quit'
telnet> quit
Connection closed.
```