### PR TITLE
Recruiter space access: front changes

### DIFF
--- a/labonneboite/web/contact_form/views.py
+++ b/labonneboite/web/contact_form/views.py
@@ -35,6 +35,21 @@ ACTION_NAMES = [
     'other',
 ]
 
+ACTION_NAME_TO_TITLE = {
+    'update_coordinates':
+        "Demande de modification des informations d'une entreprise",
+    'update_jobs':
+        """
+            Demande de modification des métiers pour lesquels
+            une entreprise reçoit des candidatures spontanées
+        """,
+    'delete':
+        "Demande de suppression d'une entreprise",
+    'other':
+        "Autre demande",
+}
+
+
 def office_identification_required(function):
     """
     Decorator that validates office identification info.
@@ -108,18 +123,21 @@ def change_info_or_apply_for_job(siret=None):
 def ask_recruiter_pe_connect():
     """
     Ask recruiters if they wants to be connected with their Pole Emploi recruiter account
-    in order to validate their identity more quickly/easely
+    in order to validate their identity more quickly/easily.
     """
     action_name = get_action_name()
     if not action_name:
         flash('Une erreur inattendue est survenue, veuillez sélectionner à nouveau une action', 'error')
         return redirect(url_for('contact_form.ask_action'))
 
+    title = ACTION_NAME_TO_TITLE.get(action_name, '')
+
     return render_template(
         'contact_form/ask_recruiter_pe_connect.html',
         use_lba_template=is_recruiter_from_lba(),
         siret=request.args.get('siret', ''),
         action_name=action_name,
+        title=title,
         custom_ga_pageview='/recruteur/%s/connexion' % action_name,
     )
 

--- a/labonneboite/web/static/css/_global_classes.css
+++ b/labonneboite/web/static/css/_global_classes.css
@@ -93,6 +93,10 @@
     color: #222;
 }
 
+.inline-block {
+    display: inline-block;
+}
+
 /* Responsive utilities.
 =========================================================================== */
 

--- a/labonneboite/web/static/css/forms.css
+++ b/labonneboite/web/static/css/forms.css
@@ -192,9 +192,49 @@ textarea.form-error,
     margin-bottom: 50px;
 }
 
-.verification-form .logo-pe-connect img {
-    width: 500px;
+/* ################################## */
+/* ##### Recruiter access form ###### */
+/* ################################## */
+
+.verification-form #button-container {
+    margin: 3rem auto;
+    width: 48%;
+    height: 100%;
 }
+
+@media (max-width: 400px) {
+    .verification-form #button-container {
+        width: 100%;
+    }
+}
+
+.verification-form #button-container > p {
+    margin: 0 auto;
+}
+
+/* PE connect button */
+.verification-form .logo-pe-connect img {
+    width: 100%;
+}
+
+.verification-form .btn {
+    /* Same look as PE connect button which is an image */
+    width: 97%; /* The PE connect image contains transparent margins... */
+    color: white;
+    background-color: #1b2e57;
+    font-size: 1rem;
+    border-radius: 39px;
+    margin: 0 auto;
+
+    /* Children will be vertically centered thanks to the following: */
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+
+
+
 .contact-form > div {
     margin-top: 30px;
 }

--- a/labonneboite/web/static/css/lba-design.css
+++ b/labonneboite/web/static/css/lba-design.css
@@ -77,8 +77,9 @@ a.btn.btn-small {
 }
 .verification-form, .application-text {
     background: white;
-    padding: 40px 80px 80px 80px;
+    padding: 6%;
 }
+
 .verification-form p, .application-text p {
     color: #444;
 }

--- a/labonneboite/web/templates/base.html
+++ b/labonneboite/web/templates/base.html
@@ -235,8 +235,10 @@
       window.CSRF_TOKEN = "{{ csrf_token() }}";
   </script>
 
-  {% block scripts %}{% endblock %}
+  {# Load libraries before template scripts to make jQuery and co available. #}
   {% assets "js_all" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
+
+  {% block scripts %}{% endblock %}
 
   {% if tilkee_enabled %}
   <script>

--- a/labonneboite/web/templates/base_lba.html
+++ b/labonneboite/web/templates/base_lba.html
@@ -39,7 +39,11 @@
     {% block content %}{% endblock %}
   </main>
 
+  {# Load libraries before template scripts to make jQuery and co available. #}
   {% assets "js_all" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
+
+  {% block scripts %}{% endblock %}
+
   {% assets "recruiter_form" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
 
   {% include "includes/ga.html" %}

--- a/labonneboite/web/templates/contact_form/ask_action.html
+++ b/labonneboite/web/templates/contact_form/ask_action.html
@@ -1,22 +1,37 @@
 {% if use_lba_template %}
-  {% extends 'base_lba.html' %}
+    {% extends 'base_lba.html' %}
 {% else %}
-  {% extends 'base.html' %}
+    {% extends 'base.html' %}
 {% endif %}
 
 {% block title %}{{ title }}{% endblock %}
 
 {% block content %}
-<div class="lbb-content">
-  <div class="lbb-single-column-content action-chooser-form">
 
-    <h2>Que voulez-vous faire ?</h2>
+    {% if use_lba_template %}
+        {% set origin='labonnealternance' %}
+    {% else %}
+        {% set origin=None %}
+    {% endif %}
 
-    <a class="btn btn-small" href="{{ url_for('contact_form.ask_recruiter_pe_connect', siret=siret, action_name='update_coordinates', origin=('labonnealternance' if use_lba_template else '')) }}">Modifier les coordonnées de mon entreprise</a>
-    <a class="btn btn-small" href="{{ url_for('contact_form.ask_recruiter_pe_connect', siret=siret, action_name='update_jobs', origin=('labonnealternance' if use_lba_template else '')) }}">Modifier les métiers pour lesquels je reçois des candidatures spontanées</a>
-    <a class="btn btn-small" href="{{ url_for('contact_form.ask_recruiter_pe_connect', siret=siret, action_name='delete', origin=('labonnealternance' if use_lba_template else '')) }}">Supprimer mon entreprise</a>
-    <a class="btn btn-small" href="{{ url_for('contact_form.ask_recruiter_pe_connect', siret=siret, action_name='other', origin=('labonnealternance' if use_lba_template else '')) }}">Autre demande</a>
+    <div class="lbb-content">
+      <div class="lbb-single-column-content action-chooser-form">
 
-  </div>
-</div>
+        <h2>Que voulez-vous faire ?</h2>
+
+        <a class="btn btn-small" href="{{ url_for('contact_form.ask_recruiter_pe_connect', siret=siret, action_name='update_coordinates', origin=origin) }}">
+            Modifier les coordonnées d'une entreprise
+        </a>
+        <a class="btn btn-small" href="{{ url_for('contact_form.ask_recruiter_pe_connect', siret=siret, action_name='update_jobs', origin=origin) }}">
+            Modifier les métiers pour lesquels une entreprise reçoit des candidatures spontanées
+        </a>
+        <a class="btn btn-small" href="{{ url_for('contact_form.ask_recruiter_pe_connect', siret=siret, action_name='delete', origin=origin) }}">
+            Supprimer une entreprise
+        </a>
+        <a class="btn btn-small" href="{{ url_for('contact_form.ask_recruiter_pe_connect', siret=siret, action_name='other', origin=origin) }}">
+            Autre demande
+        </a>
+
+      </div>
+    </div>
 {% endblock %}

--- a/labonneboite/web/templates/contact_form/ask_recruiter_pe_connect.html
+++ b/labonneboite/web/templates/contact_form/ask_recruiter_pe_connect.html
@@ -4,37 +4,56 @@
     {% extends 'base.html' %}
 {% endif %}
 
-{% block title %}Demande de modification des informations de mon entreprise{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 
 {% block content %}
-<div class="lbb-content">
-    <div class="lbb-single-column-content verification-form">
+    {% if use_lba_template %}
+        {% set origin='labonnealternance' %}
+    {% else %}
+        {% set origin=None %}
+    {% endif %}
 
-        <h2>Demande de modification des informations de mon entreprise</h2>
+    <div class="lbb-content">
+        <div class="lbb-single-column-content verification-form">
 
-        <p class="text-center">Veuillez utiliser vos identifiants Pôle emploi “accès recruteur” pour une prise en
-            compte plus rapide de vos modifications.</p>
+            <h2>{{ title }}</h2>
 
-        <p class="text-center">
-            {% if use_lba_template %}
-            <a class="logo-pe-connect rgpd-consent-required" title="Se connecter avec Pôle Emploi recruteur" href="{{ url_for('auth.peam_recruiter_connect', action_name=action_name, siret=siret, origin='labonnealternance' )}}">
-                <img src="/static/images/logo-pe-connect.svg" alt="Se connecter avec Pôle emploi recruteur">
-            </a>
-            {% else %}
-            <a class="logo-pe-connect rgpd-consent-required" title="Se connecter avec Pôle Emploi recruteur" href="{{ url_for('auth.peam_recruiter_connect', action_name=action_name, siret=siret) }}">
-                <img src="/static/images/logo-pe-connect.svg" alt="Se connecter avec Pôle emploi recruteur">
-            </a>
-            {% endif %}
-        </p>
-        <p class="text-center">
-            {% if use_lba_template %}
-            <a class="btn btn-small" href="{{ url_for('contact_form.change_info', action_name=action_name, siret=siret, no_pe_connect=1, origin='labonnealternance') }}">Je
-                n'ai pas d'identifiants Pôle emploi</a>
-            {% else %}
-            <a class="btn btn-small" href="{{ url_for('contact_form.change_info', action_name=action_name, siret=siret, no_pe_connect=1) }}">Je
-                n'ai pas d'identifiants Pôle emploi</a>
-            {% endif %}
-        </p>
+            <div id="button-container">
+                <p class="text-center">
+                    <a class="logo-pe-connect rgpd-consent-required" title="Se connecter avec Pôle Emploi recruteur" href="{{ url_for('auth.peam_recruiter_connect', action_name=action_name, siret=siret, origin=origin )}}">
+                        <img src="/static/images/logo-pe-connect.svg" alt="Se connecter avec Pôle emploi recruteur">
+                    </a>
+                </p>
+                <p class="text-center">
+                    <a class="btn" href="{{ url_for('contact_form.change_info', action_name=action_name, siret=siret, no_pe_connect=1, origin=origin) }}">
+                        <span class="inline-block">Je n'ai pas d'identifiants Pôle Emploi</span>
+                    </a>
+                </p>
+            </div>
+        </div>
     </div>
-</div>
+
+{% endblock %}
+
+{% block scripts %}
+    <script type="text/javascript">
+        (function($) {
+
+          $(window).load( function () {
+            $('#button-container .btn').resizeButton();
+          });
+
+          $.fn.resizeButton = function () {
+            var buttons = $(this);
+            var pe_connect_button = $('#button-container .logo-pe-connect img');
+
+            // The PE connect button has transparent margins so we need
+            // to remove them to get its real height.
+            var height = pe_connect_button.innerHeight() - 23;
+            if (height > 0) {
+                buttons.height(height);
+            }
+          };
+        })(jQuery)
+    </script>
 {% endblock %}


### PR DESCRIPTION
An AB test showed that having a big PE connect button and a tiny "I don't have PE credentials"
leads to many drop-offs.

This commit:
- sets the same size for both PE and not PE connect buttons,
- adds a utility CSS class `inline-block`,
- makes sure that jQuery and other libraries are loaded before the "scripts" block in templates,
- refactors a recruiter access template to avoid repetitions,
- changes the wording in recruiter access form.

## La bonne boite from a computer
![Screenshot_2019-07-26 Demande de modification des informations d'une entreprise La Bonne Boite(1)](https://user-images.githubusercontent.com/6150920/61963474-f0854b00-afcb-11e9-9a68-8813090794d1.png)

## La bonne boite from an iPhone
![Capture d’écran - 2019-07-26 à 17 08 15](https://user-images.githubusercontent.com/6150920/61963480-f844ef80-afcb-11e9-9919-f545f652f615.png)

## La bonne alternance from a computer
![Screenshot_2019-07-26 Demande de modification des informations d'une entreprise La Bonne Boite(2)](https://user-images.githubusercontent.com/6150920/61963487-fbd87680-afcb-11e9-9fdc-0f58e875351d.png)

## La bonne alternance from an iPhone
![Capture d’écran - 2019-07-26 à 17 15 03](https://user-images.githubusercontent.com/6150920/61963493-fed36700-afcb-11e9-90f3-498613cca929.png)

## Recruiters access action buttons

![Screenshot_2019-07-26 Que voulez-vous faire La Bonne Boite](https://user-images.githubusercontent.com/6150920/61963654-67badf00-afcc-11e9-8657-d474f11621b1.png)
