### PR TITLE
Fix isochrone precompute SPOF

### DIFF
--- a/labonneboite/common/maps/precompute.py
+++ b/labonneboite/common/maps/precompute.py
@@ -1,4 +1,6 @@
+from flask import current_app
 from huey import RedisHuey
+import redis
 
 from labonneboite.conf import settings
 
@@ -41,4 +43,10 @@ def isochrones(location):
     """
     for mode in travel.TRAVEL_MODES:
         for duration in constants.ISOCHRONE_DURATIONS_MINUTES:
-            isochrone(location, duration, mode=mode)
+            try:
+                isochrone(location, duration, mode=mode)
+            except redis.ConnectionError as e:
+                # Ignore redis connection errors -- precompute is temporarily
+                # unavailable, deal with it
+                current_app.logger.exception(e)
+                return


### PR DESCRIPTION
Whenever redis master was not available, precompute became impossible.
This was causing 500 errors on /entreprises search and partial
unavailability of the service. Here, we fix the 500 error and log an
error message instead. This does not solve the root cause of the redis
connection error, but at least we can deal with it.