### PR TITLE
fix a visual bug in PRO version

### DIFF
--- a/labonneboite/web/static/css/badges.css
+++ b/labonneboite/web/static/css/badges.css
@@ -1,7 +1,7 @@
 /* Badges.
 =========================================================================== */
 
-[class^="badge"] {
+.badge {
     background-color: #636c72;
     border-radius: 0.25rem;
     color: #fff;


### PR DESCRIPTION
There was something dirty in the CSS which was making the badges :nauseated_face: in some places

Before fix:

![screenshot_20200220_134441](https://user-images.githubusercontent.com/715377/74958073-329e3000-53e7-11ea-83e3-d7bffceecec0.png)

After fix:

![screenshot_20200220_134409](https://user-images.githubusercontent.com/715377/74958090-36ca4d80-53e7-11ea-936f-e02a296de14a.png)
