### PR TITLE
Add history table to keep track of importer jobs execution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# as a .gitignore, a .dockerignore file enables to tell docker to not take the 
+# files/folders that are listed below 
+
+# ignore virtualenvs
+venv 

--- a/labonneboite/alembic/versions/eeee4b88f161_add_history_importer_jobs_table.py
+++ b/labonneboite/alembic/versions/eeee4b88f161_add_history_importer_jobs_table.py
@@ -1,0 +1,36 @@
+"""
+Add history importer jobs table
+Revision ID: eeee4b88f161
+Revises: c4c5f7a025c4
+Create Date: 2020-03-30 12:01:57.047087
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+# Revision identifiers, used by Alembic.
+revision = 'eeee4b88f161'
+down_revision = 'ccc88fc92e0f'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+
+    op.create_table(
+        'history_importer_jobs',
+        sa.Column('id', mysql.INTEGER(display_width=11), nullable=False),
+        sa.Column('start_date', mysql.DATETIME()),
+        sa.Column('end_date', mysql.DATETIME()),
+        sa.Column('job_name', mysql.TEXT(collation='utf8mb4_unicode_ci')),
+        sa.Column('status', mysql.INTEGER()),
+        sa.Column('exception', mysql.TEXT(collation='utf8mb4_unicode_ci')),
+        sa.Column('trace_log', mysql.TEXT(collation='utf8mb4_unicode_ci')),
+        sa.PrimaryKeyConstraint('id'),
+        mysql_collate='utf8mb4_unicode_ci',
+        mysql_default_charset='utf8mb4',
+        mysql_engine='InnoDB'
+    )
+
+def downgrade():
+    op.drop_table('history_importer_jobs')

--- a/labonneboite/importer/jobs/check_dpae.py
+++ b/labonneboite/importer/jobs/check_dpae.py
@@ -1,8 +1,9 @@
 import sys
+import os 
 
 from labonneboite.importer import settings
 from labonneboite.importer import util as import_util
-from labonneboite.importer.util import parse_dpae_line
+from labonneboite.importer.util import parse_dpae_line, history_importer_job_decorator
 from labonneboite.importer.jobs.common import logger
 
 
@@ -57,14 +58,16 @@ def check_file(dpae_filename):
     check_complete_test(dpae_filename)
     logger.info("all tests passed with flying colors!")
 
+class NoDataException(Exception):
+    pass
 
+@history_importer_job_decorator(os.path.basename(__file__))
 def run():
     filename = import_util.detect_runnable_file("dpae")
     if filename:
         check_file(filename)
-        sys.exit(0)
     else:
-        sys.exit(-1)
+        raise NoDataException
 
 if __name__ == '__main__':
     run()

--- a/labonneboite/importer/jobs/check_etablissements.py
+++ b/labonneboite/importer/jobs/check_etablissements.py
@@ -1,12 +1,19 @@
 import sys
-from labonneboite.importer import util as import_util
+import os
 
+from labonneboite.importer import util as import_util
+from labonneboite.importer.util import history_importer_job_decorator
+
+
+class NoDataException(Exception):
+    pass
+
+
+@history_importer_job_decorator(os.path.basename(__file__))
 def run():
     filename = import_util.detect_runnable_file("etablissements")
-    if filename:
-        sys.exit(0)
-    else:
-        sys.exit(-1)
+    if not filename:
+        raise NoDataException
 
 if __name__ == '__main__':
     run()

--- a/labonneboite/importer/jobs/compute_scores.py
+++ b/labonneboite/importer/jobs/compute_scores.py
@@ -11,11 +11,13 @@ import sys
 import multiprocessing as mp
 from multiprocessing.dummy import Pool as ThreadPool
 from functools import partial
+import os
 
 from labonneboite.common import departements as dpt
 from labonneboite.importer import settings
 from labonneboite.importer import compute_score
 from labonneboite.importer import util as import_util
+from labonneboite.importer.util import history_importer_job_decorator
 from labonneboite.common.util import timeit
 from labonneboite.importer.jobs.base import Job
 from labonneboite.importer.jobs.common import logger
@@ -114,7 +116,7 @@ class ScoreComputingJob(Job):
         logger.info("compute_scores FINISHED")
         return results
 
-
+@history_importer_job_decorator(os.path.basename(__file__))
 @timeit
 def run_main():
     import_util.clean_temporary_tables()

--- a/labonneboite/importer/jobs/extract_dpae.py
+++ b/labonneboite/importer/jobs/extract_dpae.py
@@ -11,11 +11,12 @@ import time
 from datetime import datetime
 import sys
 from sqlalchemy.exc import OperationalError
+import os
 
 from labonneboite.importer import settings
 from labonneboite.importer import util as import_util
 from labonneboite.common.util import timeit
-from labonneboite.importer.util import parse_dpae_line, InvalidRowException
+from labonneboite.importer.util import parse_dpae_line, InvalidRowException, history_importer_job_decorator
 from labonneboite.importer.models.computing import DpaeStatistics, ImportTask, Hiring
 from labonneboite.importer.jobs.base import Job
 from labonneboite.importer.jobs.common import logger
@@ -193,6 +194,7 @@ class DpaeExtractJob(Job):
         logger.info("finished importing dpae...")
         return something_new
 
+@history_importer_job_decorator(os.path.basename(__file__))
 def run_main():
     import logging
     logging.basicConfig(level=logging.DEBUG)

--- a/labonneboite/importer/jobs/extract_dpae.py
+++ b/labonneboite/importer/jobs/extract_dpae.py
@@ -20,6 +20,7 @@ from labonneboite.importer.util import parse_dpae_line, InvalidRowException, his
 from labonneboite.importer.models.computing import DpaeStatistics, ImportTask, Hiring
 from labonneboite.importer.jobs.base import Job
 from labonneboite.importer.jobs.common import logger
+from labonneboite.common.database import db_session
 
 
 class DpaeExtractJob(Job):
@@ -176,11 +177,14 @@ class DpaeExtractJob(Job):
                 last_import=datetime.now(),
                 most_recent_data_date=self.last_historical_data_date_in_file,
             )
-            statistics.save()
+            db_session.add(statistics)
+            db_session.commit()
+            logger.info("First way to insert DPAE statistics in DB : OK")
         except OperationalError:
             # For an obscure reason, the DpaeStatistics way to insert does not work on the bonaparte server
             # So we insert it directly via an SQL query
             # This job has been broken for more than a year, only way to fix it : 
+            db_session.rollback()
             last_import_date = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
             most_recent_date = self.last_historical_data_date_in_file.strftime('%Y-%m-%d %H:%M:%S')
             query = f"insert into dpae_statistics (last_import, most_recent_data_date) values ('{last_import_date}','{most_recent_date}')"
@@ -189,6 +193,7 @@ class DpaeExtractJob(Job):
             con.commit()
             cur.close()
             con.close()
+            logger.info("Second way to insert DPAE statistics in DB : OK")
 
 
         logger.info("finished importing dpae...")

--- a/labonneboite/importer/jobs/extract_etablissements.py
+++ b/labonneboite/importer/jobs/extract_etablissements.py
@@ -1,9 +1,11 @@
 from urllib.parse import urlparse
 import pandas as pd
 import validators
+import os
 
 from labonneboite.importer import settings
 from labonneboite.importer import util as import_util
+from labonneboite.importer.util import history_importer_job_decorator
 from labonneboite.common.util import timeit
 from labonneboite.importer.models.computing import ImportTask
 from labonneboite.importer.models.computing import RawOffice
@@ -444,7 +446,7 @@ class EtablissementExtractJob(Job):
 
         return offices
 
-
+@history_importer_job_decorator(os.path.basename(__file__))
 def run():
     etablissement_filename = import_util.detect_runnable_file("etablissements")
     task = EtablissementExtractJob(etablissement_filename)

--- a/labonneboite/importer/jobs/geocode.py
+++ b/labonneboite/importer/jobs/geocode.py
@@ -9,6 +9,7 @@ https://adresse.data.gouv.fr/faq
 """
 from multiprocessing import Manager, Pool
 import io
+import os
 import csv
 import time
 import requests
@@ -20,6 +21,7 @@ from labonneboite.common.database import db_session
 from labonneboite.common.load_data import load_city_codes
 from labonneboite.importer import settings
 from labonneboite.importer import util as import_util
+from labonneboite.importer.util import history_importer_job_decorator
 from labonneboite.common.util import timeit
 from labonneboite.importer.models.computing import Geolocation
 from labonneboite.importer.jobs.base import Job
@@ -388,7 +390,7 @@ class GeocodeJob(Job):
         logger.info("validated coordinates !")
         logger.info("completed geocoding task.")
 
-
+@history_importer_job_decorator(os.path.basename(__file__))
 def run_main():
     geocode_task = GeocodeJob()
     geocode_task.run()

--- a/labonneboite/importer/jobs/populate_flags.py
+++ b/labonneboite/importer/jobs/populate_flags.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from shutil import copyfile
 
 from labonneboite.importer import util as import_util
+from labonneboite.importer.util import history_importer_job_decorator
 from labonneboite.common.util import timeit
 from labonneboite.importer import settings
 from labonneboite.importer.jobs.common import logger
@@ -137,7 +138,7 @@ def make_link_file_to_new_archive(archive_path):
     except OSError:
         copyfile(archive_path, link_path)
 
-
+@history_importer_job_decorator(os.path.basename(__file__))
 def run_main():
     prepare_flags_junior_and_senior()
     prepare_flag_handicap()

--- a/labonneboite/importer/jobs/validate_scores.py
+++ b/labonneboite/importer/jobs/validate_scores.py
@@ -2,10 +2,12 @@
 """
 Validates scoring data produced by compute_scores.
 """
+import os
 from labonneboite.importer import sanity
 from labonneboite.importer.jobs.common import logger
+from labonneboite.importer.util import history_importer_job_decorator
 
-
+@history_importer_job_decorator(os.path.basename(__file__))
 def run():
     errors = sanity.check_scores()
     if errors:

--- a/labonneboite/importer/models/computing.py
+++ b/labonneboite/importer/models/computing.py
@@ -222,3 +222,45 @@ class LogsActivityDPAEClean(CRUDMixin, Base):
     duree_prise_en_charge = Column(Integer)
     dn_tailleetablissement = Column(Integer)
     code_postal = Column(Text)
+
+
+# FIXME : Replace with Enum if possible
+StatusJobExecution = {
+    'start' : 0,
+    'done' : 1,
+    'error' : 2
+}
+
+class HistoryImporterJobs(CRUDMixin, Base):
+    """
+    Used to store details about the running of the different importer jobs
+    """
+    __tablename__ = "history_importer_jobs"
+
+    _id = Column('id', BigInteger, primary_key=True)
+    start_date = Column(DateTime, default=datetime.datetime.utcnow)
+    end_date = Column(DateTime, default=None)
+    job_name = Column(Text)
+    status = Column(Integer)
+    exception = Column(Text, default=None)
+    trace_log = Column(Text, default=None)
+
+    @classmethod
+    def is_job_done(cls, job):
+        most_recent_job_history = cls.query.filter_by(job_name=job).order_by(cls.start_date.desc()).first()
+
+        #No rows matching to the job in the database
+        if most_recent_job_history is None:
+            return False
+
+        # check if the most recent row in db for this job has start_date < 25 days
+        # 25 days totally arbitrary, we run importer each month, and with this function, 
+        # we want it to check the job status for the current importer cycle, not the previous one
+        now = datetime.datetime.now()
+        most_recent_start_date = most_recent_job_history.start_date
+        delta = now - most_recent_start_date
+        if delta.days > 25:
+            return False
+
+        return most_recent_job_history.status == StatusJobExecution['done']
+

--- a/labonneboite/scripts/data_scripts/check_data_datalake.py
+++ b/labonneboite/scripts/data_scripts/check_data_datalake.py
@@ -47,12 +47,13 @@ class DatalakeFile:
 # For etablissement file : Print the lines that are related to a siret
 # Example : Check some fields that seem to contain wrong values for a specific siret
 # Used it when we wantee to check the effectif field for this specific siret
-def filter_on_siret_etab(self, df, siret):
+def filter_on_siret_etab(df, siret):
     df_filtre = df[df.dc_siretetablissement == siret]
     print(df_filtre)
+    import ipdb;ipdb.set_trace()
 
 # Here, we needed to extract all mail cleans that datalake sent us via the etablissement file
-def extract_mail_clean_etab(self, df):
+def extract_mail_clean_etab(df):
     df = df[['dc_siretetablissement', 'dc_raisonsocialeentreprise', 'dc_emailcorrespondant']]
     df = df.dropna(subset=['dc_emailcorrespondant'])
     df = df.drop_duplicates()
@@ -77,7 +78,7 @@ def run_function_etab():
 # METHODS DPAE
 # ----------------------
 
-def filter_on_siret_dpae(self, df, siret):
+def filter_on_siret_dpae(df, siret):
     df_filtre = df[df.kc_siret == siret]
     print(df_filtre)
 

--- a/labonneboite/scripts/data_scripts/check_data_datalake.py
+++ b/labonneboite/scripts/data_scripts/check_data_datalake.py
@@ -1,6 +1,11 @@
 import os
 import pandas as pd
 
+pd.set_option('display.max_rows', None)
+pd.set_option('display.max_columns', None)
+pd.set_option('display.width', None)
+pd.set_option('display.max_colwidth', -1)
+
 # NOT DONE TO RUN IN LOCAL DEV
 # A util script to run outside the current lbb dev to check validity of files values sent by datalake
 # To copy and paste on the importer server (Bonaparte) where data are located
@@ -72,8 +77,9 @@ def run_function_etab():
     etab_data = DatalakeFile('etab')
     df = etab_data.read_file()
     # extract_mail_clean(df)
-    # filter_on_siret_etab(df, 44443604200261)
-    extract_siret_lbb_supprimes(df)
+    
+    filter_on_siret_etab(df, 34918135400029)
+    # extract_siret_lbb_supprimes(df)
 
 # METHODS DPAE
 # ----------------------
@@ -81,6 +87,7 @@ def run_function_etab():
 def filter_on_siret_dpae(df, siret):
     df_filtre = df[df.kc_siret == siret]
     print(df_filtre)
+    import ipdb; ipdb.set_trace()
 
 # Main function for dpae
 def run_function_dpae():


### PR DESCRIPTION
For the deployment of importer on k8s stack, the jobs need to be sure
that the previous one has been executed.
There won't be any jenkins for orchestration of jobs.
And, there is also antoher reason.
With this, we can store exceptions that occure in importer in the database !