### PR TITLE
post release fixes for related romes feature

### DIFF
--- a/labonneboite/web/search/views.py
+++ b/labonneboite/web/search/views.py
@@ -312,7 +312,7 @@ def entreprises():
             related_romes.sort(key=lambda rome_: rome_.get('score'))
             related_romes = related_romes[:settings.MAX_RELATED_ROMES]
             if (len(related_romes) > 0):
-                flash('Nouvelle fonctionnalité : Grâce aux nouveaux filtres, élargissez votre recherche aux métiers qui recrutent !', 'success')
+                flash('Nouvelle fonctionnalité : Grâce aux nouveaux filtres, élargissez votre recherche aux métiers qui recrutent !', 'info')
 
 
     # Build form

--- a/labonneboite/web/static/css/alerts.css
+++ b/labonneboite/web/static/css/alerts.css
@@ -27,7 +27,7 @@
 }
 
 .alert-success {
-    background: #1c86f2;
+    background: #19c158;
     color: #fff;
 }
 

--- a/labonneboite/web/static/js/results.js
+++ b/labonneboite/web/static/js/results.js
@@ -208,15 +208,17 @@ var trackOutboundLink = function(url) {
     // handle related rome initial search
     var related_rome_initial = $('#related_rome_initial');
     related_rome_initial.on('click', function(e) {
-      var j = shown_form.find('#j');
-      var ij = hidden_form.find('#ij');
+      var ij = hidden_form.find('#ij'); // initial search (related romes case)
+      var j = shown_form.find('#j'); // j stands for job
+      var hiddenJ = hidden_form.find('#j'); // this is the same "job" param, in the hidden form
       var occupation = hidden_form.find('#occupation');
       var rome_description = $(e.target).attr('data-rome-description');
       var rome_description_slug = $(e.target).attr('data-rome-description-slug');
       ij.val('');
       j.val(rome_description);
+      hiddenJ.val(rome_description);
       occupation.val(rome_description_slug);
-      shown_form.submit();
+      hidden_form.submit();
     })
 
     // trigger hotjar
@@ -227,15 +229,17 @@ var trackOutboundLink = function(url) {
     // handle related romes
     var related_romes = $('#form-related_romes');
     related_romes.on('click', function(e) {
-      var j = shown_form.find('#j');
-      var ij = hidden_form.find('#ij');
+      var ij = hidden_form.find('#ij'); // initial search (related romes case)
+      var j = shown_form.find('#j'); // j stands for job
+      var hiddenJ = hidden_form.find('#j'); // this is the same "job" param, in the hidden form
       var occupation = hidden_form.find('#occupation');
       var rome_description = $(e.target).attr('data-rome-description');
       var rome_description_slug = $(e.target).attr('data-rome-description-slug');
       ij.val(j.val());
       j.val(rome_description);
+      hiddenJ.val(rome_description);
       occupation.val(rome_description_slug);
-      shown_form.submit();
+      hidden_form.submit();
     });
 
     // trigger hotjar


### PR DESCRIPTION
## flash color fixes

1. fix success flash color
1. use info flash for info message of related romes

## related romes fixes for URL

To reproduce the bug:

1. open `/entreprises?j=Animation+de+vente&l=Puget-Ville+83390&naf=&h=1&tr=&d=10&sort=score&ij=&occupation=animation-de-vente&lat=43.27875&lon=6.155912&departments=&tr=`
2. click on suggested rome "Vente en animalerie", this opens up `/entreprises?j=Animation+de+site+multim%C3%A9dia&l=Colomieu+01300&naf=&h=1&tr=car&d=10&sort=score&ij=Animation+de+site+multim%C3%A9dia&occupation=assistanat-commercial&lat=45.733422&lon=5.622902&departments=&tr=car` 
3. it should be `/entreprises?j=Vente+en+animalerie&l=Puget-Ville+83390&naf=&h=1&tr=&d=10&sort=score&ij=Animation+de+vente&occupation=vente-en-animalerie&lat=43.27875&lon=6.155912&departments=&tr=`

