### PR TITLE
add score and score alternance to maj in es

### DIFF
--- a/labonneboite/scripts/create_index.py
+++ b/labonneboite/scripts/create_index.py
@@ -658,6 +658,7 @@ def update_offices(table):
                     # Apply changes in ElasticSearch.
                     body = {'doc':
                         {'email': office.email, 'phone': office.tel, 'website': office.website,
+                         "score": office.score, "score_alternance": office.score_alternance,
                         'flag_alternance': 1 if office.flag_alternance else 0}
                     }
 


### PR DESCRIPTION
Some update about company NAF score was missing in `create_index.py`, it should fix the problem encountered by SAVers.