### PR TITLE
fix: PELBB-354: store the search ROME in favorites to display the same score

### DIFF
--- a/labonneboite/alembic/env.py
+++ b/labonneboite/alembic/env.py
@@ -5,6 +5,8 @@ from alembic import context
 from sqlalchemy import create_engine
 
 from labonneboite.common.database import Base, get_db_string
+import labonneboite.common.models
+import labonneboite.importer.models
 
 
 # this is the Alembic Config object, which provides

--- a/labonneboite/alembic/versions/78df44030210_add_favorite_rome.py
+++ b/labonneboite/alembic/versions/78df44030210_add_favorite_rome.py
@@ -1,0 +1,25 @@
+"""
+add favorite rome
+
+Revision ID: 78df44030210
+Revises: 29cdae903fb3
+Create Date: 2022-02-03 14:11:43.111858
+"""
+from alembic import op
+from sqlalchemy.dialects import mysql
+import sqlalchemy as sa
+
+# Revision identifiers, used by Alembic.
+revision = '78df44030210'
+down_revision = '29cdae903fb3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('user_favorite_offices',
+                  sa.Column('rome_code', sa.String(length=5), nullable=True))
+
+
+def downgrade():
+    op.drop_column('user_favorite_offices', 'rome_code')

--- a/labonneboite/common/csv.py
+++ b/labonneboite/common/csv.py
@@ -1,0 +1,7 @@
+from csv import *
+
+
+class excel_semi(excel):
+    delimiter = ";"
+
+register_dialect('excel-semi', excel_semi)

--- a/labonneboite/doc/README-code-profiling.md
+++ b/labonneboite/doc/README-code-profiling.md
@@ -70,7 +70,3 @@ def get_scores_by_rome(office, office_to_update=None):
 ```
 
 You can perfectly profile methods in other parts of the code than `create_index.py`.
-
-Here is an example of output:
-
-![](https://www.evernote.com/l/ABJdN3iVDEJFgLeH2HgHyYOVMjOYK0a30e4B/image.png)

--- a/labonneboite/importer/models/__init__.py
+++ b/labonneboite/importer/models/__init__.py
@@ -1,0 +1,16 @@
+from .computing import (
+    Hiring,
+    RawOffice,
+    ExportableOffice,
+    Geolocation,
+    ImportTask,
+    DpaeStatistics,
+    LogsIDPEConnect,
+    LogsActivity,
+    LogsActivityRecherche,
+    LogsActivityDPAEClean,
+    HistoryImporterJobs,
+    PerfImporterCycleInfos,
+    PerfPredictionAndEffectiveHirings,
+    PerfDivisionPerRome,
+)

--- a/labonneboite/tests/web/api/test_api.py
+++ b/labonneboite/tests/web/api/test_api.py
@@ -211,7 +211,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             self.assertEqual(len(data['companies']), 2)
 
@@ -225,7 +225,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
 
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(len(data['companies']), 1)
@@ -288,7 +288,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(len(data['companies']), 1)
             self.assertEqual(data['companies'][0]['headcount_text'], '10 000 salariés et plus')
@@ -401,7 +401,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data_direct_search = json.loads(rv.data.decode())
+            data_direct_search = self.get_json(rv)
 
             params = self.add_security_params({
                 'commune_id': self.positions['caen']['commune_id'],
@@ -410,7 +410,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data_keyword_search = json.loads(rv.data.decode())
+            data_keyword_search = self.get_json(rv)
 
             self.assertEqual(data_direct_search, data_keyword_search)
 
@@ -433,7 +433,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['rome_code'], 'M1607')
             self.assertEqual(data['rome_label'], 'Secrétariat')
 
@@ -462,7 +462,7 @@ class ApiCompanyListTest(ApiBaseTest):
                 'rome_codes': rome,
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['rome_code'], rome)
             self.assertEqual(data['rome_label'], 'Animation de vente')
 
@@ -563,7 +563,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 3)
             self.assertEqual(len(data['companies']), 2)
 
@@ -579,7 +579,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(len(data['companies']), 1)
 
@@ -597,7 +597,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(len(data['companies']), 1)
             self.assertEqual(data['companies'][0]['siret'], '00000000000004')
@@ -617,7 +617,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             self.assertEqual(
                 set([c['siret'] for c in data['companies']]),
@@ -642,7 +642,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(data['companies'][0]['siret'], '00000000000007')
 
@@ -692,7 +692,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(len(data['companies']), 1)
             self.assertIn('rome_code=D1405', data['companies'][0]['url'])
@@ -715,7 +715,7 @@ class ApiCompanyListTest(ApiBaseTest):
             with mock.patch.object(scoring_util, 'SCORE_FOR_ROME_MINIMUM', 0):
                 rv = self.app.get(self.url_for("api.company_list", **params))
                 self.assertEqual(rv.status_code, 200)
-                data = json.loads(rv.data.decode())
+                data = self.get_json(rv)
                 self.assertEqual(data['companies_count'], 1)
                 self.assertEqual(len(data['companies']), 1)
 
@@ -780,7 +780,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 0)
             self.assertEqual(len(data['companies']), 0)
 
@@ -795,7 +795,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(len(data['companies']), 3)
             for company in data['companies']:
                 self.assertNotIn('email', company)
@@ -823,7 +823,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(len(data['companies']), 1)
             self.assertEqual(data['companies'][0]['siret'], '00000000000004')
@@ -837,7 +837,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(len(data['companies']), 1)
             self.assertEqual(data['companies'][0]['siret'], '00000000000005')
@@ -856,7 +856,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             self.assertEqual(len(data['companies']), 2)
             self.assertIn('matched_rome_code', data['companies'][0])
@@ -914,7 +914,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             self.assertEqual(len(data['companies']), 2)
             self.assertNotEqual(data['companies'][0]['naf'], data['companies'][1]['naf'])
@@ -930,7 +930,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(len(data['companies']), 1)
             self.assertEqual(data['companies'][0]['siret'], '00000000000006')
@@ -944,7 +944,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(len(data['companies']), 1)
             self.assertEqual(data['companies'][0]['siret'], '00000000000007')
@@ -960,7 +960,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             self.assertEqual(len(data['companies']), 2)
 
@@ -1000,7 +1000,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             self.assertEqual(len(data['companies']), 2)
             self.assertEqual(data["companies"][0]['siret'], '00000000000008')
@@ -1018,7 +1018,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             self.assertEqual(len(data['companies']), 2)
             sirets = set([data['companies'][0]['siret'], data['companies'][1]['siret']])
@@ -1058,7 +1058,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             self.assertEqual(len(data['companies']), 2)
 
@@ -1072,7 +1072,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(len(data['companies']), 1)
             self.assertEqual(data['companies'][0]['siret'], '00000000000012')
@@ -1088,7 +1088,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(len(data['companies']), 1)
             self.assertEqual(data['companies'][0]['siret'], '00000000000013')
@@ -1103,7 +1103,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(len(data['companies']), 1)
             self.assertEqual(data['companies'][0]['siret'], '00000000000004')
@@ -1118,7 +1118,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             sirets = {c['siret']: c for c in data['companies']}
             self.assertEqual(sorted(sirets.keys()), ['00000000000015', '00000000000016'])
             self.assertFalse(sirets['00000000000015']['alternance'])
@@ -1151,7 +1151,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             sirets = set([data['companies'][0]['siret'], data['companies'][1]['siret']])
             self.assertEqual(sirets, set(['00000000000017', '00000000000018']))
@@ -1167,7 +1167,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             sirets = set([data['companies'][0]['siret'], data['companies'][1]['siret']])
             self.assertEqual(sirets, set(['00000000000017', '00000000000018']))
@@ -1182,7 +1182,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             sirets = set([data['companies'][0]['siret'], data['companies'][1]['siret']])
             self.assertEqual(sirets, set(['00000000000017', '00000000000018']))
@@ -1196,7 +1196,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(data['companies'][0]['siret'], '00000000000017')
 
@@ -1221,7 +1221,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             sirets = set([data['companies'][0]['siret'], data['companies'][1]['siret']])
             self.assertEqual(sirets, set(['00000000000017', '00000000000018']))
@@ -1235,7 +1235,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 2)
             sirets = set([data['companies'][0]['siret'], data['companies'][1]['siret']])
             self.assertEqual(sirets, set(['00000000000017', '00000000000018']))
@@ -1249,7 +1249,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(data['companies'][0]['siret'], '00000000000017')
 
@@ -1262,7 +1262,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['companies_count'], 1)
             self.assertEqual(data['companies'][0]['siret'], '00000000000018')
 
@@ -1275,7 +1275,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_filter_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
 
             # Check distance filter
             self.assertEqual(data['filters']['distance']['less_30_km'], 4)
@@ -1313,7 +1313,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_filter_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             nafs_expected = {
                 '4910Z': ['4910Z', 2, 'Transport ferroviaire interurbain de voyageurs'],
                 '4920Z': ['4920Z', 1, 'Transports ferroviaires de fret'],
@@ -1335,7 +1335,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_filter_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['filters']['headcount']['small'], 2)
             self.assertEqual(data['filters']['headcount']['big'], 1)
 
@@ -1347,7 +1347,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_filter_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['filters']['headcount']['small'], 2)
             self.assertEqual(data['filters']['headcount']['big'], 1)
 
@@ -1361,7 +1361,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_filter_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['filters']['contract']['dpae'], 3)
             self.assertEqual(data['filters']['contract']['alternance'], 1)
 
@@ -1373,7 +1373,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_filter_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['filters']['contract']['dpae'], 3)
             self.assertEqual(data['filters']['contract']['alternance'], 1)
 
@@ -1387,7 +1387,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_filter_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
 
             self.assertEqual(data['filters']['distance']['less_10_km'], 3)
             self.assertEqual(data['filters']['distance']['less_30_km'], 4)
@@ -1403,7 +1403,7 @@ class ApiCompanyListTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_filter_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             self.assertEqual(data['filters']['distance']['less_10_km'], 3)
             self.assertEqual(data['filters']['distance']['less_30_km'], 4)
             self.assertEqual(data['filters']['distance']['less_50_km'], 5)
@@ -1420,7 +1420,7 @@ class ApiCompanyListTest(ApiBaseTest):
 
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
 
             self.assertTrue(data['companies_count'] >= 1)
             expect = '/entreprises/commune/{}/rome/{}'.format(self.positions['toulon']['commune_id'], 'N4403')
@@ -1441,7 +1441,7 @@ class ApiCompanyListTest(ApiBaseTest):
 
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
 
             self.assertTrue(data['companies_count'] >= 1)
             expect = '/entreprises/commune/{}/rome/{}'.format(self.positions['toulon']['commune_id'], 'N4403')
@@ -1463,7 +1463,7 @@ class ApiCompanyListTest(ApiBaseTest):
 
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
 
             # ensure we return home URL and not search URL
             self.assertNotIn('/entreprises', data['url'])
@@ -1482,7 +1482,7 @@ class ApiCompanyListTest(ApiBaseTest):
 
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
 
             self.assertEqual(data['companies_count'], 0)
             self.assertEqual(len(data['companies']), 0)
@@ -1501,7 +1501,7 @@ class ApiCompanyListTest(ApiBaseTest):
 
             rv = self.app.get(self.url_for("api.company_count", **params))
             self.assertEqual(rv.status_code, 200)
-            data_count = json.loads(rv.data.decode())
+            data_count = self.get_json(rv)
 
             self.assertIn('companies_count', data_count)
             self.assertTrue(data_count['companies_count'] >= 1)
@@ -1509,7 +1509,7 @@ class ApiCompanyListTest(ApiBaseTest):
 
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data_list = json.loads(rv.data.decode())
+            data_list = self.get_json(rv)
 
             self.assertIn('companies_count', data_list)
             self.assertEqual(data_list['companies_count'], data_count['companies_count'])
@@ -1604,7 +1604,7 @@ class ApiOffersOfficesListTest(ApiBaseTest):
                 mock_response.assert_called_once()
 
             self.assertEqual(rv.status_code, 200)
-            result = json.loads(rv.data.decode())
+            result = self.get_json(rv)
             self.assertEqual(result['companies_count'], 5)
             self.assertEqual(len(result['companies']), 5)
             for office_json in result['companies']:
@@ -1634,7 +1634,7 @@ class ApiOffersOfficesListTest(ApiBaseTest):
                 mock_response.assert_called_once()
 
             self.assertEqual(rv.status_code, 200)
-            result = json.loads(rv.data.decode())
+            result = self.get_json(rv)
             self.assertEqual(result['companies_count'], 5)
             self.assertEqual(len(result['companies']), 5)
             for office_json in result['companies']:
@@ -1658,7 +1658,7 @@ class ApiOffersOfficesListTest(ApiBaseTest):
                 self.assertEqual(mock_response.call_count, 2)
 
             self.assertEqual(rv.status_code, 200)
-            result = json.loads(rv.data.decode())
+            result = self.get_json(rv)
             self.assertEqual(result['companies_count'], 5)
             self.assertEqual(len(result['companies']), 5)
             for office_json in result['companies']:
@@ -1750,7 +1750,7 @@ class ApiCompanyListTrackingCodesTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
             company_url = data['companies'][0]['url']
 
         self.assertTrackingCodesEqual(company_url, 'web', 'api__labonneboite', 'api__labonneboite')
@@ -1766,7 +1766,7 @@ class ApiCompanyListTrackingCodesTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
 
             company_url = data['companies'][0]['url']
             self.assertTrackingCodesEqual(company_url, 'web', 'api__labonneboite', 'api__labonneboite__someuser')
@@ -1782,7 +1782,7 @@ class ApiCompanyListTrackingCodesTest(ApiBaseTest):
             })
             rv = self.app.get(self.url_for("api.company_list", **params))
             self.assertEqual(rv.status_code, 200)
-            data = json.loads(rv.data.decode())
+            data = self.get_json(rv)
 
             company_url = data['url']
             self.assertTrackingCodesEqual(company_url, 'web', 'api__labonneboite', 'api__labonneboite__someuser')

--- a/labonneboite/tests/web/api/test_api_base.py
+++ b/labonneboite/tests/web/api/test_api_base.py
@@ -615,3 +615,10 @@ class ApiBaseTest(DatabaseTest):
     def get_fixture(self, fixture):
         fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures', fixture)
         return json.load(open(fixture_path))
+
+    def get_json(self, response: Response) -> dict:
+        self.assertEqual(response.content_type, 'application/json')
+        data: bytes = response.data
+        text: str = data.decode(response.content_encoding or 'utf-8')
+        json_response = json.loads(text)
+        return json_response

--- a/labonneboite/tests/web/api/test_api_base.py
+++ b/labonneboite/tests/web/api/test_api_base.py
@@ -1,493 +1,511 @@
-
-import os
+import copy
 import json
+import os
+from operator import itemgetter
 
-from labonneboite.common.models import Office
-from labonneboite.tests.test_base import DatabaseTest
-from labonneboite.web.api import util
-from labonneboite.conf import settings
+from flask.wrappers import Response
+
 from labonneboite.common import es
 from labonneboite.common import mapping as mapping_util
 from labonneboite.common import scoring as scoring_util
+from labonneboite.common.models import Office
+from labonneboite.conf import settings
+from labonneboite.tests.test_base import DatabaseTest
+from labonneboite.web.api import util
+
+POSITIONS = {
+    'bayonville_sur_mad': {
+        'coords': [{
+            'lat': 49,
+            'lon': 6,
+        }],
+        'zip_code': '54890',
+        'commune_id': '54055',
+    },
+    'caen': {
+        'coords': [{
+            'lat': 49.1812497463,
+            'lon': -0.372499354315,
+        }],
+        'zip_code': '14000',
+        'commune_id': '14118',
+    },
+    'metz': {
+        'coords': [{
+            'lat': 49.133333,
+            'lon': 6.166667,
+        }],
+        'zip_code': '57050',
+        'commune_id': '57463',
+    },
+    'nantes': {
+        'coords': [{
+            'lat': 47.217222,
+            'lon': -1.553889,
+        }],
+        'zip_code': '44000',
+        'commune_id': '44109',
+    },
+    # City close to Nantes
+    'reze': {
+        'coords': [{
+            'lat': 47.2,
+            'lon': -1.566667,
+        }],
+        'zip_code': '44400',
+        'commune_id': '44143',
+    },
+    'lille': {
+        'coords': [{
+            'lat': 50.633333,
+            'lon': 3.066667,
+        }],
+        'zip_code': '59800',
+        'commune_id': '59350',
+    },
+    'toulouse': {
+        'coords': [{
+            'lat': 43.600000,
+            'lon': 1.433333,
+        }],
+        'zip_code': '31500',
+        'commune_id': '31555',
+    },
+    'pau': {
+        'coords': [{
+            'lat': 43.300000,
+            'lon': -0.366667,
+        }],
+        'zip_code': '64000',
+        'commune_id': '64445',
+    },
+    'poitiers': {
+        'coords': [{
+            'lat': 46.5833,
+            'lon': 0.3333,
+        }],
+        'zip_code': '86000',
+        'commune_id': '86194',
+    },
+    'paris': {
+        'coords': [{
+            'lat': 48.87950,
+            'lon': 2.283439,
+        }],
+        'zip_code': '75004',
+        'commune_id': '75056',
+    },
+    'neuilly-sur-seine': {
+        'coords': [{
+            'lat': 48.884831,
+            'lon': 2.26851,
+        }],
+        'zip_code': '92200',
+        'commune_id': '92051',
+    },
+    # For filters in response tests
+    'toulon': {
+        'coords': [{
+            'lat': 43.1167,
+            'lon': 5.9333,
+        }],
+        'zip_code': '83000',
+        'commune_id': '83137',
+    },
+    # Located at 15km of Toulon
+    'hyeres': {
+        'coords': [{
+            'lat': 43.1167,
+            'lon': 6.1167,
+        }],
+        'zip_code': '83400',
+        'commune_id': '83069',
+    },
+    # Located at 35km of Toulon
+    'aubagne': {
+        'coords': [{
+            'lat': 43.283329,
+            'lon': 5.56667,
+        }],
+        'zip_code': '13400',
+        'commune_id': '13005',
+    },
+    # Located at 60km of Toulon
+    'draguignan': {
+        'coords': [{
+            'lat': 43.53772,
+            'lon': 6.464993,
+        }],
+        'zip_code': '83300',
+        'commune_id': '83050',
+    },
+    # Located at 500km of Toulon
+    'limoges': {
+        'coords': [{
+            'lat': 45.849998,
+            'lon': 1.25,
+        }],
+        'zip_code': '87000',
+        'commune_id': '87085',
+    },
+}
+
+DOCS = [
+    {
+        'naf': '4646Z',  # Map to ROME D1405.
+        'siret': '00000000000001',
+        'company_name': 'Raison sociale 1',
+        'score': 68,
+        'score_alternance': 18,
+        'headcount': 11,
+        'locations': POSITIONS['bayonville_sur_mad']['coords'],
+        'name': 'Office 1',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['bayonville_sur_mad']['zip_code'][0:2],
+    },
+    {
+        'naf': '4646Z',  # Map to ROME D1405.
+        'siret': '00000000000002',
+        'company_name': 'Raison sociale 2',
+        'score': 69,
+        'score_alternance': 18,
+        'headcount': 31,
+        'locations': POSITIONS['bayonville_sur_mad']['coords'],
+        'name': 'Office 2',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['bayonville_sur_mad']['zip_code'][0:2],
+    },
+    {
+        'naf': '4646Z',  # Map to ROME D1405.
+        'siret': '00000000000003',
+        'score': 70,
+        'score_alternance': 18,
+        'headcount': 31,
+        'locations': POSITIONS['bayonville_sur_mad']['coords'],
+        'name': 'Office 3',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['bayonville_sur_mad']['zip_code'][0:2],
+    },
+    {
+        'naf': '4646Z',  # Map to ROME D1405.
+        'siret': '00000000000004',
+        'score': 71,
+        'score_alternance': 18,
+        'headcount': 31,
+        'locations': POSITIONS['caen']['coords'],
+        'name': 'Office 4',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['caen']['zip_code'][0:2],
+    },
+    {
+        'naf': '9511Z',  # Map to ROME M1801.
+        'siret': '00000000000005',
+        'score': 71,
+        'score_alternance': 18,
+        'headcount': 31,
+        'locations': POSITIONS['caen']['coords'],
+        'name': 'Office 5',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['caen']['zip_code'][0:2],
+    },
+    # For NAF filter
+    {
+        'naf': '4771Z',  # Map to ROME D1508.
+        'siret': '00000000000006',
+        'score': 75,
+        'score_alternance': 18,
+        'headcount': 31,
+        'locations': POSITIONS['metz']['coords'],
+        'name': 'Office 6',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['metz']['zip_code'][0:2],
+    },
+    {
+        'naf': '4711F',  # Map to ROME D1508.
+        'siret': '00000000000007',
+        'score': 70,
+        'score_alternance': 18,
+        'headcount': 50,
+        'locations': POSITIONS['metz']['coords'],
+        'name': 'Office 7',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['metz']['zip_code'][0:2],
+    },
+    # For result sort
+    {
+        'naf': '9529Z',  # Map to ROME D1211
+        'siret': '00000000000008',
+        'score': 75,
+        'score_alternance': 51,
+        'headcount': 50,
+        'locations': POSITIONS['nantes']['coords'],
+        'name': 'Office 8',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['nantes']['zip_code'][0:2],
+    },
+    {
+        'naf': '4741Z',  # Map to ROME D1211
+        'siret': '00000000000009',
+        'score': 99,
+        'score_alternance': 51,
+        'headcount': 50,
+        'locations': POSITIONS['reze']['coords'],  # City close to Nantes
+        'name': 'Office 9',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['reze']['zip_code'][0:2],
+    },
+    # For contract filter
+    {
+        'naf': '4752B',  # Map to Rome D1213
+        'siret': '00000000000010',
+        'score': 78,
+        'score_alternance': 0,
+        'headcount': 34,
+        'locations': POSITIONS['lille']['coords'],
+        'name': 'Office 10',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['lille']['zip_code'][0:2],
+    },
+    {
+        'naf': '4752B',  # Map to Rome D1213
+        'siret': '00000000000011',
+        'score': 82,
+        'score_alternance': 80,
+        'headcount': 65,
+        'locations': POSITIONS['lille']['coords'],
+        'name': 'Office 11',
+        'flag_alternance': 1,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['lille']['zip_code'][0:2],
+    },
+    # For headcount filter
+    {
+        'naf': '7022Z',  # Map to Rome M1202
+        'siret': '00000000000012',
+        'score': 82,
+        'score_alternance': 18,
+        'headcount': 11,
+        'locations': POSITIONS['toulouse']['coords'],
+        'name': 'Office 12',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['toulouse']['zip_code'][0:2],
+    },
+    {
+        'naf': '7022Z',  # Map to Rome M1202
+        'siret': '00000000000013',
+        'score': 82,
+        'score_alternance': 18,
+        'headcount': 22,
+        'locations': POSITIONS['toulouse']['coords'],
+        'name': 'Office 13',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['toulouse']['zip_code'][0:2],
+    },
+    # For headcount_text
+    {
+        'naf': '3212Z',  # Map to Rome B1603
+        'siret': '00000000000014',
+        'score': 80,
+        'score_alternance': 18,
+        'headcount': 53,  # headcount_text : '10 000 salariés et plus'
+        'locations': POSITIONS['pau']['coords'],
+        'name': 'Office 14',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['pau']['zip_code'][0:2],
+    },
+    # For flag_alternance in response
+    {
+        'naf': '3212Z',  # Map to Rome B1603
+        'siret': '00000000000015',
+        'score': 80,
+        'score_alternance': 18,
+        'headcount': 53,
+        'locations': POSITIONS['poitiers']['coords'],
+        'name': 'Office 15',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['poitiers']['zip_code'][0:2],
+    },
+    {
+        'naf': '3212Z',  # Map to Rome B1603
+        'siret': '00000000000016',
+        'score': 70,
+        'score_alternance': 80,
+        'headcount': 53,
+        'locations': POSITIONS['poitiers']['coords'],
+        'name': 'Office 16',
+        'flag_alternance': 1,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['poitiers']['zip_code'][0:2],
+    },
+    # For filter_by_department and filter_by_flag_pmsmp
+    {
+        'naf': '5229A',  # Map to Rome N1202
+        'siret': '00000000000017',
+        'score': 90,
+        'score_alternance': 18,
+        'headcount': 53,
+        'locations': POSITIONS['paris']['coords'],
+        'name': 'Office 17',
+        'flag_alternance': 0,
+        'flag_pmsmp': 1,
+        'department': POSITIONS['paris']['zip_code'][0:2],
+    },
+    {
+        'naf': '5229A',  # Map to Rome N1202
+        'siret': '00000000000018',
+        'score': 78,
+        'score_alternance': 18,
+        'headcount': 53,
+        'locations': POSITIONS['neuilly-sur-seine']['coords'],
+        'name': 'Office 18',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['neuilly-sur-seine']['zip_code'][0:2],
+    },
+    # For filters in response tests
+    {
+        'naf': '4910Z',  # Map to Rome N4403
+        'siret': '00000000000019',
+        'score': 76,
+        'score_alternance': 18,
+        'headcount': 0o1,
+        'locations': POSITIONS['toulon']['coords'],
+        'name': 'Office 19',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['toulon']['zip_code'][0:2],
+    },
+    {
+        'naf': '4910Z',  # Map to Rome N4403
+        'siret': '00000000000020',
+        'score': 90,
+        'score_alternance': 18,
+        'headcount': 0o3,
+        'locations': POSITIONS['toulon']['coords'],
+        'name': 'Office 20',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['toulon']['zip_code'][0:2],
+    },
+    {
+        'naf': '4920Z',  # Map to Rome N4403
+        'siret': '00000000000021',
+        'score': 43,
+        'score_alternance': 18,
+        'headcount': 53,
+        'locations': POSITIONS['toulon']['coords'],
+        'name': 'Office 21',
+        'flag_alternance': 1,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['toulon']['zip_code'][0:2],
+    },
+    # For distance filter => between 10-30km
+    {
+        'naf': '4910Z',  # Map to Rome N4403
+        'siret': '00000000000023',
+        'score': 89,
+        'score_alternance': 18,
+        'headcount': 31,
+        'locations': POSITIONS['hyeres']['coords'],  # 15km of Toulon
+        'name': 'Office 23',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['hyeres']['zip_code'][0:2],
+    },
+    # For distance filter => between 30-50km
+    {
+        'naf': '4910Z',  # Map to Rome N4403
+        'siret': '00000000000024',
+        'score': 30,
+        'score_alternance': 18,
+        'headcount': 12,
+        'locations': POSITIONS['aubagne']['coords'],  # 35km of Toulon
+        'name': 'Office 24',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['aubagne']['zip_code'][0:2],
+    },
+    # For distance between 50-100km
+    {
+        'naf': '4910Z',  # Map to Rome N4403
+        'siret': '00000000000025',
+        'score': 82,
+        'score_alternance': 18,
+        'headcount': 11,
+        'locations': POSITIONS['draguignan']['coords'],  # 60km of Toulon
+        'name': 'Office 25',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['draguignan']['zip_code'][0:2],
+    },
+    # For distance filter => between 100-3000km
+    {
+        'naf': '4910Z',  # Map to Rome N4403
+        'siret': '00000000000026',
+        'score': 67,
+        'score_alternance': 18,
+        'headcount': 51,
+        'locations': POSITIONS['limoges']['coords'],  # 500km of Toulon
+        'name': 'Office 26',
+        'flag_alternance': 0,
+        'flag_pmsmp': 0,
+        'department': POSITIONS['limoges']['zip_code'][0:2],
+    },
+    # For boost scores tests
+    {
+        'naf': '4646Z',  # Map to Rome D1405
+        'siret': '00000000000027',
+        'score': 43,
+        'score_alternance': 18,
+        'headcount': 53,
+        'locations': POSITIONS['toulon']['coords'],
+        'name': 'Office 27',
+        'flag_alternance': 1,
+        'flag_pmsmp': 0,
+        'boosted_alternance_romes': None,
+        'boosted_romes': {
+            'A1503': True,
+            'J1301': True,
+            'K1304': True,
+            'K1303': True,
+            'A1408': True,
+            'K1302': True,
+            'M1607': True
+        },
+        'scores_by_rome': {
+            'M1607': 45,
+            'G1203': 52,
+            'M1203': 20,
+            'K1207': 60,
+            'K1302': 50,
+            'K1303': 51
+        },
+        'scores_alternance_by_rome': None,
+        'department': POSITIONS['toulon']['zip_code'][0:2],
+    },
+]
 
 
 class ApiBaseTest(DatabaseTest):
 
-    positions = {
-        'bayonville_sur_mad': {
-            'coords': [{
-                'lat': 49,
-                'lon': 6,
-            }],
-            'zip_code': '54890',
-            'commune_id': '54055',
-        },
-        'caen': {
-            'coords': [{
-                'lat': 49.1812497463,
-                'lon': -0.372499354315,
-            }],
-            'zip_code': '14000',
-            'commune_id': '14118',
-        },
-        'metz': {
-            'coords': [{
-                'lat': 49.133333,
-                'lon': 6.166667,
-            }],
-            'zip_code': '57050',
-            'commune_id': '57463',
-        },
-        'nantes': {
-            'coords': [{
-                'lat': 47.217222,
-                'lon': -1.553889,
-            }],
-            'zip_code': '44000',
-            'commune_id': '44109',
-        },
-        # City close to Nantes
-        'reze': {
-            'coords': [{
-                'lat': 47.2,
-                'lon': -1.566667,
-            }],
-            'zip_code': '44400',
-            'commune_id': '44143',
-        },
-        'lille': {
-            'coords': [{
-                'lat': 50.633333,
-                'lon': 3.066667,
-            }],
-            'zip_code': '59800',
-            'commune_id': '59350',
-        },
-        'toulouse': {
-            'coords': [{
-                'lat': 43.600000,
-                'lon': 1.433333,
-            }],
-            'zip_code': '31500',
-            'commune_id': '31555',
-        },
-        'pau': {
-            'coords': [{
-                'lat': 43.300000,
-                'lon': -0.366667,
-            }],
-            'zip_code': '64000',
-            'commune_id': '64445',
-        },
-        'poitiers': {
-            'coords': [{
-                'lat': 46.5833,
-                'lon': 0.3333,
-            }],
-            'zip_code': '86000',
-            'commune_id': '86194',
-        },
-        'paris': {
-            'coords': [{
-                'lat': 48.87950,
-                'lon': 2.283439,
-            }],
-            'zip_code': '75004',
-            'commune_id': '75056',
-        },
-        'neuilly-sur-seine': {
-            'coords': [{
-                'lat': 48.884831,
-                'lon': 2.26851,
-            }],
-            'zip_code': '92200',
-            'commune_id': '92051',
-        },
-        # For filters in response tests
-        'toulon': {
-            'coords': [{
-                'lat': 43.1167,
-                'lon': 5.9333,
-            }],
-            'zip_code': '83000',
-            'commune_id': '83137',
-        },
-        # Located at 15km of Toulon
-        'hyeres': {
-            'coords': [{
-                'lat': 43.1167,
-                'lon': 6.1167,
-            }],
-            'zip_code': '83400',
-            'commune_id': '83069',
-        },
-        # Located at 35km of Toulon
-        'aubagne': {
-            'coords': [{
-                'lat': 43.283329,
-                'lon': 5.56667,
-            }],
-            'zip_code': '13400',
-            'commune_id': '13005',
-        },
-        # Located at 60km of Toulon
-        'draguignan': {
-            'coords': [{
-                'lat': 43.53772,
-                'lon': 6.464993,
-            }],
-            'zip_code': '83300',
-            'commune_id': '83050',
-        },
-        # Located at 500km of Toulon
-        'limoges': {
-            'coords': [{
-                'lat': 45.849998,
-                'lon': 1.25,
-            }],
-            'zip_code': '87000',
-            'commune_id': '87085',
-        },
+    positions = copy.deepcopy(POSITIONS)
 
-    }
-
-    def setUp(self, *args, **kwargs):
-        super(ApiBaseTest, self).setUp(*args, **kwargs)
-
-        # Insert test data into Elasticsearch.
-        docs = [
-            {
-                'naf': '4646Z',  # Map to ROME D1405.
-                'siret': '00000000000001',
-                'company_name': 'Raison sociale 1',
-                'score': 68,
-                'score_alternance': 18,
-                'headcount': 11,
-                'locations': self.positions['bayonville_sur_mad']['coords'],
-                'name': 'Office 1',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['bayonville_sur_mad']['zip_code'][0:2],
-            },
-            {
-                'naf': '4646Z',  # Map to ROME D1405.
-                'siret': '00000000000002',
-                'company_name': 'Raison sociale 2',
-                'score': 69,
-                'score_alternance': 18,
-                'headcount': 31,
-                'locations': self.positions['bayonville_sur_mad']['coords'],
-                'name': 'Office 2',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['bayonville_sur_mad']['zip_code'][0:2],
-            },
-            {
-                'naf': '4646Z',  # Map to ROME D1405.
-                'siret': '00000000000003',
-                'score': 70,
-                'score_alternance': 18,
-                'headcount': 31,
-                'locations': self.positions['bayonville_sur_mad']['coords'],
-                'name': 'Office 3',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['bayonville_sur_mad']['zip_code'][0:2],
-            },
-            {
-                'naf': '4646Z',  # Map to ROME D1405.
-                'siret': '00000000000004',
-                'score': 71,
-                'score_alternance': 18,
-                'headcount': 31,
-                'locations': self.positions['caen']['coords'],
-                'name': 'Office 4',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['caen']['zip_code'][0:2],
-            },
-            {
-                'naf': '9511Z',  # Map to ROME M1801.
-                'siret': '00000000000005',
-                'score': 71,
-                'score_alternance': 18,
-                'headcount': 31,
-                'locations': self.positions['caen']['coords'],
-                'name': 'Office 5',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['caen']['zip_code'][0:2],
-            },
-            # For NAF filter
-            {
-                'naf': '4771Z',  # Map to ROME D1508.
-                'siret': '00000000000006',
-                'score': 75,
-                'score_alternance': 18,
-                'headcount': 31,
-                'locations': self.positions['metz']['coords'],
-                'name': 'Office 6',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['metz']['zip_code'][0:2],
-            },
-            {
-                'naf': '4711F',  # Map to ROME D1508.
-                'siret': '00000000000007',
-                'score': 70,
-                'score_alternance': 18,
-                'headcount': 50,
-                'locations': self.positions['metz']['coords'],
-                'name': 'Office 7',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['metz']['zip_code'][0:2],
-            },
-            # For result sort
-            {
-                'naf': '9529Z', # Map to ROME D1211
-                'siret': '00000000000008',
-                'score': 75,
-                'score_alternance': 51,
-                'headcount': 50,
-                'locations': self.positions['nantes']['coords'],
-                'name': 'Office 8',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['nantes']['zip_code'][0:2],
-            },
-            {
-                'naf': '4741Z', # Map to ROME D1211
-                'siret': '00000000000009',
-                'score': 99,
-                'score_alternance': 51,
-                'headcount': 50,
-                'locations': self.positions['reze']['coords'], # City close to Nantes
-                'name': 'Office 9',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['reze']['zip_code'][0:2],
-            },
-            # For contract filter
-            {
-                'naf': '4752B', # Map to Rome D1213
-                'siret': '00000000000010',
-                'score': 78,
-                'score_alternance': 0,
-                'headcount': 34,
-                'locations': self.positions['lille']['coords'],
-                'name': 'Office 10',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['lille']['zip_code'][0:2],
-            },
-            {
-                'naf': '4752B', # Map to Rome D1213
-                'siret': '00000000000011',
-                'score': 82,
-                'score_alternance': 80,
-                'headcount': 65,
-                'locations': self.positions['lille']['coords'],
-                'name': 'Office 11',
-                'flag_alternance': 1,
-                'flag_pmsmp': 0,
-                'department': self.positions['lille']['zip_code'][0:2],
-            },
-            # For headcount filter
-            {
-                'naf': '7022Z', # Map to Rome M1202
-                'siret': '00000000000012',
-                'score': 82,
-                'score_alternance': 18,
-                'headcount': 11,
-                'locations': self.positions['toulouse']['coords'],
-                'name': 'Office 12',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['toulouse']['zip_code'][0:2],
-            },
-            {
-                'naf': '7022Z',  # Map to Rome M1202
-                'siret': '00000000000013',
-                'score': 82,
-                'score_alternance': 18,
-                'headcount': 22,
-                'locations': self.positions['toulouse']['coords'],
-                'name': 'Office 13',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['toulouse']['zip_code'][0:2],
-            },
-            # For headcount_text
-            {
-                'naf': '3212Z',  # Map to Rome B1603
-                'siret': '00000000000014',
-                'score': 80,
-                'score_alternance': 18,
-                'headcount': 53, # headcount_text : '10 000 salariés et plus'
-                'locations': self.positions['pau']['coords'],
-                'name': 'Office 14',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['pau']['zip_code'][0:2],
-            },
-            # For flag_alternance in response
-            {
-                'naf': '3212Z',  # Map to Rome B1603
-                'siret': '00000000000015',
-                'score': 80,
-                'score_alternance': 18,
-                'headcount': 53,
-                'locations': self.positions['poitiers']['coords'],
-                'name': 'Office 15',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['poitiers']['zip_code'][0:2],
-            },
-            {
-                'naf': '3212Z',  # Map to Rome B1603
-                'siret': '00000000000016',
-                'score': 70,
-                'score_alternance': 80,
-                'headcount': 53,
-                'locations': self.positions['poitiers']['coords'],
-                'name': 'Office 16',
-                'flag_alternance': 1,
-                'flag_pmsmp': 0,
-                'department': self.positions['poitiers']['zip_code'][0:2],
-            },
-            # For filter_by_department and filter_by_flag_pmsmp
-            {
-                'naf': '5229A',  # Map to Rome N1202
-                'siret': '00000000000017',
-                'score': 90,
-                'score_alternance': 18,
-                'headcount': 53,
-                'locations': self.positions['paris']['coords'],
-                'name': 'Office 17',
-                'flag_alternance': 0,
-                'flag_pmsmp': 1,
-                'department': self.positions['paris']['zip_code'][0:2],
-            },
-            {
-                'naf': '5229A',  # Map to Rome N1202
-                'siret': '00000000000018',
-                'score': 78,
-                'score_alternance': 18,
-                'headcount': 53,
-                'locations': self.positions['neuilly-sur-seine']['coords'],
-                'name': 'Office 18',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['neuilly-sur-seine']['zip_code'][0:2],
-            },
-            # For filters in response tests
-            {
-                'naf': '4910Z',  # Map to Rome N4403
-                'siret': '00000000000019',
-                'score': 76,
-                'score_alternance': 18,
-                'headcount': 0o1,
-                'locations': self.positions['toulon']['coords'],
-                'name': 'Office 19',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['toulon']['zip_code'][0:2],
-            },
-            {
-                'naf': '4910Z',  # Map to Rome N4403
-                'siret': '00000000000020',
-                'score': 90,
-                'score_alternance': 18,
-                'headcount': 0o3,
-                'locations': self.positions['toulon']['coords'],
-                'name': 'Office 20',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['toulon']['zip_code'][0:2],
-            },
-            {
-                'naf': '4920Z',  # Map to Rome N4403
-                'siret': '00000000000021',
-                'score': 43,
-                'score_alternance': 18,
-                'headcount': 53,
-                'locations': self.positions['toulon']['coords'],
-                'name': 'Office 21',
-                'flag_alternance': 1,
-                'flag_pmsmp': 0,
-                'department': self.positions['toulon']['zip_code'][0:2],
-            },
-            # For distance filter => between 10-30km
-            {
-                'naf': '4910Z',  # Map to Rome N4403
-                'siret': '00000000000023',
-                'score': 89,
-                'score_alternance': 18,
-                'headcount': 31,
-                'locations': self.positions['hyeres']['coords'], # 15km of Toulon
-                'name': 'Office 23',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['hyeres']['zip_code'][0:2],
-            },
-            # For distance filter => between 30-50km
-            {
-                'naf': '4910Z',  # Map to Rome N4403
-                'siret': '00000000000024',
-                'score': 30,
-                'score_alternance': 18,
-                'headcount': 12,
-                'locations': self.positions['aubagne']['coords'], # 35km of Toulon
-                'name': 'Office 24',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['aubagne']['zip_code'][0:2],
-            },
-            # For distance between 50-100km
-            {
-                'naf': '4910Z',  # Map to Rome N4403
-                'siret': '00000000000025',
-                'score': 82,
-                'score_alternance': 18,
-                'headcount': 11,
-                'locations': self.positions['draguignan']['coords'], # 60km of Toulon
-                'name': 'Office 25',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['draguignan']['zip_code'][0:2],
-            },
-            # For distance filter => between 100-3000km
-            {
-                'naf': '4910Z',  # Map to Rome N4403
-                'siret': '00000000000026',
-                'score': 67,
-                'score_alternance': 18,
-                'headcount': 51,
-                'locations': self.positions['limoges']['coords'], # 500km of Toulon
-                'name': 'Office 26',
-                'flag_alternance': 0,
-                'flag_pmsmp': 0,
-                'department': self.positions['limoges']['zip_code'][0:2],
-            },
-            # For boost scores tests
-            {
-                'naf': '4646Z',  # Map to Rome D1405
-                'siret': '00000000000027',
-                'score': 43,
-                'score_alternance': 18,
-                'headcount': 53,
-                'locations': self.positions['toulon']['coords'],
-                'name': 'Office 27',
-                'flag_alternance': 1,
-                'flag_pmsmp': 0,
-                'boosted_alternance_romes': None,
-                'boosted_romes': {'A1503': True, 'J1301': True, 'K1304': True, 'K1303': True, 'A1408': True, 'K1302': True, 'M1607': True},
-                'scores_by_rome': {'M1607': 45, 'G1203': 52, 'M1203': 20, 'K1207': 60, 'K1302': 50, 'K1303': 51},
-                'scores_alternance_by_rome': None,
-                'department': self.positions['toulon']['zip_code'][0:2],
-            },
-        ]
+    def get_docs(self):
+        docs = copy.deepcopy(DOCS)
         for _, doc in enumerate(docs, start=1):
             # Build scores for relevant ROME codes.
             naf = doc['naf']
@@ -520,6 +538,15 @@ class ApiBaseTest(DatabaseTest):
                     scores_alternance_by_rome[rome_code] = raw_score
             if scores_alternance_by_rome:
                 doc['scores_alternance_by_rome'] = scores_alternance_by_rome
+        return docs
+
+    def setUp(self, *args, **kwargs):
+        super(ApiBaseTest, self).setUp(*args, **kwargs)
+
+        self.docs = self.get_docs()
+
+        # Insert test data into Elasticsearch.
+        for _, doc in enumerate(self.docs, start=1):
 
             # just like in other environments, id should be the siret
             self.es.index(index=settings.ES_INDEX, doc_type=es.OFFICE_TYPE, id=doc['siret'], body=doc)
@@ -528,7 +555,7 @@ class ApiBaseTest(DatabaseTest):
         self.es.indices.flush(index=settings.ES_INDEX)
 
         # Create related Office instances into MariaDB/MySQL.
-        for doc in docs:
+        for doc in self.docs:
 
             # Set the right `commune_id` and `zipcode` depending on the location.
             commune_id = None
@@ -566,6 +593,15 @@ class ApiBaseTest(DatabaseTest):
         es_count = self.es.count(index=settings.ES_INDEX, doc_type=es.OFFICE_TYPE, body={'query': {'match_all': {}}})
         self.assertEqual(Office.query.count() + 1, es_count['count'])
 
+    def tearDown(self):
+        # Insert test data into Elasticsearch.
+        for _, doc in enumerate(self.docs, start=1):
+            # just like in other environments, id should be the siret
+            self.es.delete(index=settings.ES_INDEX, doc_type=es.OFFICE_TYPE, id=doc['siret'])
+        sirets = list(map(itemgetter('siret'), self.docs))
+        offices = Office.query.filter(Office.siret in sirets).delete()
+        super().tearDown()
+
     def add_security_params(self, params):
         """
         Utility method that add `timestamp` and `signature` keys to params.
@@ -575,7 +611,6 @@ class ApiBaseTest(DatabaseTest):
         params['timestamp'] = timestamp
         params['signature'] = signature
         return params
-
 
     def get_fixture(self, fixture):
         fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures', fixture)

--- a/labonneboite/web/templates/includes/office/header.html
+++ b/labonneboite/web/templates/includes/office/header.html
@@ -69,7 +69,10 @@
           {# START favorites. #}
           {% if show_favorites and user.is_authenticated %}
             {% if (user_favs_as_sirets is defined) and (company.siret not in user_favs_as_sirets) %}
-              <form action="{{ url_for('user.favorites_add', siret=company.siret) }}" method="post" class="form-inline">
+              <form
+                  action="{{ url_for('user.favorites_add', siret=company.siret, rome_code=rome_code) }}"
+                  method="post"
+                  class="form-inline">
                 <button class="invisible no-padding gtm-favorites-add" type="submit">
                   <span class="rounded-icon"><img class="img-icon" alt="" src="{{ url_for('static', filename='images/icons/heart.svg') }}"></span>
                   <span class="btn btn-small invisible">Garder pour plus tard</span>

--- a/labonneboite/web/templates/user/favorites_list.html
+++ b/labonneboite/web/templates/user/favorites_list.html
@@ -40,7 +40,7 @@
         </div>
       {% else %}
         {% for fav in favorites %}
-          {% with company = fav.office %}
+          {% with company = fav.office, rome_code = fav.rome_code %}
             <div class="lbb-bright-container lbb-result">
               {% with show_more_info=1 %}
                 {% include "includes/office/header.html" %}

--- a/labonneboite/web/user/views.py
+++ b/labonneboite/web/user/views.py
@@ -2,6 +2,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+import io
 
 from flask import Blueprint, Markup
 from flask import abort, current_app, flash, make_response
@@ -12,7 +13,7 @@ from flask_login import current_user
 from flask_wtf import csrf
 from social_flask_sqlalchemy.models import UserSocialAuth
 
-from labonneboite.common import activity
+from labonneboite.common import activity, csv
 from labonneboite.common.database import db_session
 from labonneboite.common.models import get_user_social_auth
 from labonneboite.common.models import Office
@@ -91,17 +92,17 @@ def personal_data_as_csv():
     """
     Download as a CSV the personal data of a user.
     """
-    header_row = 'prénom;nom;email'
-    values = [
+    output = io.StringIO()
+    writer = csv.writer(output, dialect='excel-semi')
+    writer.writerow(['prénom', 'nom', 'email'])
+    writer.writerow([
         current_user.first_name,
         current_user.last_name,
         current_user.email,
-    ]
-    content_row = ";".join(values)
-    csv_text = "%s\r\n%s" % (header_row, content_row)
+    ])
 
     return make_csv_response(
-        csv_text=csv_text,
+        csv_text=output.getvalue(),
         attachment_name='mes_données_personnelles.csv',
     )
 

--- a/labonneboite/web/user/views.py
+++ b/labonneboite/web/user/views.py
@@ -3,6 +3,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import io
+from typing import Optional
 
 from flask import Blueprint, Markup
 from flask import abort, current_app, flash, make_response
@@ -27,7 +28,6 @@ from labonneboite.common.pagination import Pagination, FAVORITES_PER_PAGE
 from labonneboite.web.user.forms import UserAccountDeleteForm
 from labonneboite.web.utils import fix_csrf_session
 
-
 userBlueprint = Blueprint('user', __name__)
 
 
@@ -42,7 +42,8 @@ def account():
     context = {}
     if user_social_auth:
         context['token'] = user_social_auth.extra_data['access_token']
-        context['token_age_in_seconds'] = int(time.time()) - user_social_auth.extra_data['auth_time'],
+        context['token_age_in_seconds'] = int(
+            time.time()) - user_social_auth.extra_data['auth_time'],
     return render_template('user/account.html', **context)
 
 
@@ -64,7 +65,8 @@ def account_delete():
         # We have to delete it because it has a foreign key to the User table.
         # We don't need to deal with the other tables of Social Auth, see:
         # https://python-social-auth.readthedocs.io/en/latest/storage.html
-        db_session.query(UserSocialAuth).filter_by(user_id=current_user.id).delete()
+        db_session.query(UserSocialAuth).filter_by(
+            user_id=current_user.id).delete()
 
         # Delete the current user.
         # The user's favorites will be deleted at the same time because of the `ondelete='CASCADE'`
@@ -118,22 +120,28 @@ def favorites_list_as_csv():
         attachment_name='mes_favoris.csv',
     )
 
+
 @userBlueprint.route('/favorites/list/download/pdf')
 @flask_login.login_required
 def favorites_list_as_pdf():
-    favorites = UserFavoriteOffice.query.filter(UserFavoriteOffice.user_id == current_user.id)
+    favorites = UserFavoriteOffice.query.filter(
+        UserFavoriteOffice.user_id == current_user.id)
     # TODO this is probably wildly inefficient. Can we do this in just one query?
     companies = [favorite.office for favorite in favorites]
     pdf_file = pdf_util.render_favorites(companies)
-    return send_file(pdf_file, mimetype='application/pdf', as_attachment=True,
-                     attachment_filename='mes_favoris.pdf', cache_timeout=5)
+    return send_file(pdf_file,
+                     mimetype='application/pdf',
+                     as_attachment=True,
+                     attachment_filename='mes_favoris.pdf',
+                     cache_timeout=5)
 
 
 def make_csv_response(csv_text, attachment_name):
     # Return csv file
     response = make_response(csv_text)
     response.headers['Content-Type'] = 'application/csv'
-    response.headers['Content-Disposition'] = 'attachment; filename=%s' % attachment_name
+    response.headers[
+        'Content-Disposition'] = 'attachment; filename=%s' % attachment_name
     return response
 
 
@@ -149,7 +157,8 @@ def favorites_list():
     except (TypeError, ValueError):
         page = 1
 
-    favorites = UserFavoriteOffice.query.filter(UserFavoriteOffice.user_id == current_user.id)
+    favorites = UserFavoriteOffice.query.filter(
+        UserFavoriteOffice.user_id == current_user.id)
     limit = FAVORITES_PER_PAGE
     pagination = Pagination(page, limit, favorites.count())
     if page > 1:
@@ -165,8 +174,9 @@ def favorites_list():
 
 
 @userBlueprint.route('/favorites/add/<siret>', methods=['POST'])
+@userBlueprint.route('/favorites/add/<siret>/<rome_code>', methods=['POST'])
 @flask_login.login_required
-def favorites_add(siret):
+def favorites_add(siret: str, rome_code: Optional[str] = None):
     """
     Add an office to the favorites of a user.
     """
@@ -181,9 +191,12 @@ def favorites_add(siret):
     if not office:
         abort(404)
 
-    UserFavoriteOffice.add_favorite(user=current_user, office=office)
+    UserFavoriteOffice.add_favorite(user=current_user,
+                                    office=office,
+                                    rome_code=rome_code)
 
-    message = '"%s - %s" a été ajouté à vos favoris !' % (office.name, office.city)
+    message = '"%s - %s" a été ajouté à vos favoris !' % (office.name,
+                                                          office.city)
     flash(Markup(message), 'success')
     activity.log('ajout-favori', siret=siret)
 
@@ -215,13 +228,15 @@ def favorites_delete(siret):
     if current_app.config['WTF_CSRF_ENABLED']:
         csrf.validate_csrf(request.form.get('csrf_token'))
 
-    fav = UserFavoriteOffice.query.filter_by(office_siret=siret, user_id=current_user.id).first()
+    fav = UserFavoriteOffice.query.filter_by(office_siret=siret,
+                                             user_id=current_user.id).first()
     if not fav:
         abort(404)
 
     fav.delete()
 
-    message = '"%s - %s" a été supprimé de vos favoris !' % (fav.office.name, fav.office.city)
+    message = '"%s - %s" a été supprimé de vos favoris !' % (fav.office.name,
+                                                             fav.office.city)
     flash(message, 'success')
     activity.log('suppression-favori', siret=siret)
 


### PR DESCRIPTION
- refacto,test: delete companies on test tearDown
- refacto,test: use a generic method to parse json of api responses
- doc: remove dead link
- refacto: use csv standard library to create csv
- fix: PELBB-354: store the search ROME in favorites to display the same score